### PR TITLE
refactor(api/bug): change ID type from `int` to `int64`

### DIFF
--- a/api_bug.go
+++ b/api_bug.go
@@ -311,7 +311,7 @@ func (s *BugService) GetBugs(
 }
 
 type GetBugsRequest struct {
-	ID                *Multi[int]        `url:"id,omitempty"`               // ID 支持多ID查询
+	ID                *Multi[int64]      `url:"id,omitempty"`               // ID 支持多ID查询
 	Title             *string            `url:"title,omitempty"`            // 标题 支持模糊匹配
 	Priority          *string            `url:"priority,omitempty"`         // 优先级。为了兼容自定义优先级，请使用 priority_label 字段，详情参考：如何兼容自定义优先级
 	PriorityLabel     *PriorityLabel     `url:"priority_label,omitempty"`   // 优先级。推荐使用这个字段
@@ -563,7 +563,7 @@ func (s *BugService) UpdateBug(
 }
 
 type UpdateBugRequest struct {
-	ID                *int               `json:"id,omitempty"`               // ID 支持多ID查询
+	ID                *int64             `json:"id,omitempty"`               // ID 支持多ID查询
 	Title             *string            `json:"title,omitempty"`            // 标题 支持模糊匹配
 	Priority          *string            `json:"priority,omitempty"`         // 优先级。为了兼容自定义优先级，请使用 priority_label 字段，详情参考：如何兼容自定义优先级
 	PriorityLabel     *PriorityLabel     `json:"priority_label,omitempty"`   // 优先级。推荐使用这个字段

--- a/api_bug_test.go
+++ b/api_bug_test.go
@@ -91,7 +91,7 @@ func TestBugService_UpdateBug(t *testing.T) {
 
 	bug, _, err := client.BugService.UpdateBug(ctx, &UpdateBugRequest{
 		WorkspaceID:   Ptr(11112222),
-		ID:            Ptr(11111222330268),
+		ID:            Ptr(int64(11111222330268)),
 		PriorityLabel: Ptr(PriorityLabelHigh),
 		Severity:      NewEnum(BugSeverityFatal, BugSeveritySerious),
 	})


### PR DESCRIPTION
fixes https://github.com/go-tapd/tapd/issues/61

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated bug request handling to use a 64-bit identifier for improved range support.
- **Tests**
	- Adjusted tests to ensure consistency with the updated identifier handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->