### PR TITLE
refactor(auth): rename username/password to clientID/clientSecret

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ import (
 )
 
 func main() {
-	client, err := tapd.NewClient("username", "password")
+	client, err := tapd.NewClient("client_id", "client_secret")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/api_label_test.go
+++ b/api_label_test.go
@@ -15,7 +15,7 @@ func TestLabelService_GetLabels(t *testing.T) {
 		assert.Equal(t, "11112222", r.URL.Query().Get("workspace_id"))
 		assert.Equal(t, "111,222", r.URL.Query().Get("id"))
 		assert.Equal(t, "test", r.URL.Query().Get("name"))
-		assert.Equal(t, "tapd-username", r.URL.Query().Get("creator"))
+		assert.Equal(t, "tapd-clientID", r.URL.Query().Get("creator"))
 		assert.Equal(t, "2024-08-26", r.URL.Query().Get("created"))
 		assert.Equal(t, "10", r.URL.Query().Get("limit"))
 		assert.Equal(t, "1", r.URL.Query().Get("page"))
@@ -28,7 +28,7 @@ func TestLabelService_GetLabels(t *testing.T) {
 		WorkspaceID: Ptr(11112222),
 		ID:          NewMulti(111, 222),
 		Name:        Ptr("test"),
-		Creator:     Ptr("tapd-username"),
+		Creator:     Ptr("tapd-clientID"),
 		Created:     Ptr("2024-08-26"),
 		Limit:       Ptr(10),
 		Page:        Ptr(1),
@@ -41,8 +41,8 @@ func TestLabelService_GetLabels(t *testing.T) {
 	assert.Equal(t, "test2", labels[0].Name)
 	assert.Equal(t, LabelColor2, labels[0].Color)
 	assert.Equal(t, "workspace", labels[0].Category)
-	assert.Equal(t, "tapd-username", labels[0].Creator)
-	assert.Equal(t, "tapd-username", labels[0].Modifier)
+	assert.Equal(t, "tapd-clientID", labels[0].Creator)
+	assert.Equal(t, "tapd-clientID", labels[0].Modifier)
 	assert.Equal(t, "2024-08-26 21:38:29", labels[0].Created)
 	assert.Equal(t, "2024-08-26 21:41:59", labels[0].Modified)
 	assert.Equal(t, "#FF6770", labels[0].ColorValue)
@@ -55,7 +55,7 @@ func TestLabelService_GetLabelCount(t *testing.T) {
 		assert.Equal(t, "11112222", r.URL.Query().Get("workspace_id"))
 		assert.Equal(t, "111,222", r.URL.Query().Get("id"))
 		assert.Equal(t, "test", r.URL.Query().Get("name"))
-		assert.Equal(t, "tapd-username", r.URL.Query().Get("creator"))
+		assert.Equal(t, "tapd-clientID", r.URL.Query().Get("creator"))
 		assert.Equal(t, "2024-08-26", r.URL.Query().Get("created"))
 
 		_, _ = w.Write(loadData(t, "internal/testdata/api/label/get_label_count.json"))
@@ -65,7 +65,7 @@ func TestLabelService_GetLabelCount(t *testing.T) {
 		WorkspaceID: Ptr(11112222),
 		ID:          NewMulti(111, 222),
 		Name:        Ptr("test"),
-		Creator:     Ptr("tapd-username"),
+		Creator:     Ptr("tapd-clientID"),
 		Created:     Ptr("2024-08-26"),
 	})
 	assert.NoError(t, err)
@@ -88,7 +88,7 @@ func TestLabelService_CreateLabel(t *testing.T) {
 		assert.Equal(t, 11112222, req.WorkspaceID)
 		assert.Equal(t, "test", req.Name)
 		assert.Equal(t, LabelColor1, req.Color)
-		assert.Equal(t, "tapd-username", req.Creator)
+		assert.Equal(t, "tapd-clientID", req.Creator)
 
 		_, _ = w.Write(loadData(t, "internal/testdata/api/label/create_label.json"))
 	}))
@@ -97,7 +97,7 @@ func TestLabelService_CreateLabel(t *testing.T) {
 		WorkspaceID: Ptr(11112222),
 		Name:        Ptr("test"),
 		Color:       Ptr(LabelColor1),
-		Creator:     Ptr("tapd-username"),
+		Creator:     Ptr("tapd-clientID"),
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, "1134190502001000812", label.ID)
@@ -105,7 +105,7 @@ func TestLabelService_CreateLabel(t *testing.T) {
 	assert.Equal(t, "test3", label.Name)
 	assert.Equal(t, LabelColor1, label.Color)
 	assert.Equal(t, "workspace", label.Category)
-	assert.Equal(t, "tapd-username", label.Creator)
+	assert.Equal(t, "tapd-clientID", label.Creator)
 	assert.Equal(t, "", label.Modifier)
 	assert.Equal(t, "2024-08-26 22:33:14", label.Created)
 	assert.Equal(t, "2024-08-26 22:33:14", label.Modified)
@@ -128,7 +128,7 @@ func TestLabelService_UpdateLabel(t *testing.T) {
 		assert.Equal(t, 1134190502001000812, req.ID)
 		assert.Equal(t, 11112222, req.WorkspaceID)
 		assert.Equal(t, LabelColor1, req.Color)
-		assert.Equal(t, "tapd-username", req.Modifier)
+		assert.Equal(t, "tapd-clientID", req.Modifier)
 
 		_, _ = w.Write(loadData(t, "internal/testdata/api/label/update_label.json"))
 	}))
@@ -137,7 +137,7 @@ func TestLabelService_UpdateLabel(t *testing.T) {
 		ID:          Ptr(1134190502001000812),
 		WorkspaceID: Ptr(11112222),
 		Color:       Ptr(LabelColor1),
-		Modifier:    Ptr("tapd-username"),
+		Modifier:    Ptr("tapd-clientID"),
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, "1134190502001000812", label.ID)
@@ -145,7 +145,7 @@ func TestLabelService_UpdateLabel(t *testing.T) {
 	assert.Equal(t, "test3", label.Name)
 	assert.Equal(t, LabelColor1, label.Color)
 	assert.Equal(t, "workspace", label.Category)
-	assert.Equal(t, "tapd-username", label.Creator)
+	assert.Equal(t, "tapd-clientID", label.Creator)
 	assert.Equal(t, "", label.Modifier)
 	assert.Equal(t, "2024-08-26 22:33:14", label.Created)
 	assert.Equal(t, "2024-08-26 22:33:14", label.Modified)

--- a/client.go
+++ b/client.go
@@ -24,8 +24,8 @@ type Client struct {
 	// baseURL for API requests.
 	baseURL *url.URL
 
-	// username, password for basic authentication.
-	username, password string
+	// clientID, clientSecret for basic authentication.
+	clientID, clientSecret string
 
 	// userAgent used for HTTP requests
 	userAgent string
@@ -52,14 +52,14 @@ type Client struct {
 
 // NewClient returns a new Tapd API client.
 // Alias for NewBasicAuthClient.
-func NewClient(username, password string, opts ...ClientOption) (*Client, error) {
-	return NewBasicAuthClient(username, password, opts...)
+func NewClient(clientID, clientSecret string, opts ...ClientOption) (*Client, error) {
+	return NewBasicAuthClient(clientID, clientSecret, opts...)
 }
 
 // NewBasicAuthClient returns a new Tapd API client with basic authentication.
-func NewBasicAuthClient(username, password string, opts ...ClientOption) (*Client, error) {
+func NewBasicAuthClient(clientID, clientSecret string, opts ...ClientOption) (*Client, error) {
 	return newClient(append(opts,
-		WithBasicAuth(username, password))...)
+		WithBasicAuth(clientID, clientSecret))...)
 }
 
 // newClient returns a new Tapd API client.
@@ -170,8 +170,8 @@ func (c *Client) NewRequest(ctx context.Context, method, path string, data any, 
 	}
 
 	// basic auth
-	if c.username != "" && c.password != "" {
-		req.SetBasicAuth(c.username, c.password)
+	if c.clientID != "" && c.clientSecret != "" {
+		req.SetBasicAuth(c.clientID, c.clientSecret)
 	}
 
 	// Set the request specific headers.

--- a/client_options.go
+++ b/client_options.go
@@ -11,11 +11,11 @@ func WithBaseURL(urlStr string) ClientOption {
 	}
 }
 
-// WithBasicAuth sets the username and password for the client
-func WithBasicAuth(username, password string) ClientOption {
+// WithBasicAuth sets the clientID and clientSecret for the client
+func WithBasicAuth(clientID, clientSecret string) ClientOption {
 	return func(c *Client) error {
-		c.username = username
-		c.password = password
+		c.clientID = clientID
+		c.clientSecret = clientSecret
 		return nil
 	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 const (
-	apiUsername     = "tapd-username"
-	apiPassword     = "tapd-password"
+	apiClientID     = "tapd-client-id"
+	apiClientSecret = "tapd-client-secret"
 	successResponse = `{
   "status": 1,
   "data": {},
@@ -29,7 +29,7 @@ func createServerClient(t *testing.T, handler http.Handler) (*httptest.Server, *
 	t.Cleanup(srv.Close)
 
 	client, err := NewClient(
-		apiUsername, apiPassword,
+		apiClientID, apiClientSecret,
 		WithBaseURL(srv.URL),
 		WithHTTPClient(NewRetryableHTTPClient(
 			WithRetryableHTTPClientLogger(log.New(os.Stderr, "", log.LstdFlags)),
@@ -52,10 +52,10 @@ func TestClient_BasicAuth(t *testing.T) {
 		assert.Equal(t, "/__/basic-auth", r.URL.Path)
 
 		// check basic auth
-		username, password, ok := r.BasicAuth()
+		clientID, clientSecret, ok := r.BasicAuth()
 		assert.True(t, ok)
-		assert.Equal(t, apiUsername, username)
-		assert.Equal(t, apiPassword, password)
+		assert.Equal(t, apiClientID, clientID)
+		assert.Equal(t, apiClientSecret, clientSecret)
 
 		// nolint:errcheck
 		fmt.Fprint(w, `{
@@ -103,10 +103,10 @@ func TestClient_NormalRequest(t *testing.T) {
 		assert.Equal(t, defaultUserAgent, r.Header.Get("User-Agent"))
 
 		// check basic auth
-		username, password, ok := r.BasicAuth()
+		clientID, clientSecret, ok := r.BasicAuth()
 		assert.True(t, ok)
-		assert.Equal(t, apiUsername, username)
-		assert.Equal(t, apiPassword, password)
+		assert.Equal(t, apiClientID, clientID)
+		assert.Equal(t, apiClientSecret, clientSecret)
 
 		fmt.Fprint(w, successResponse) // nolint:errcheck
 	}))
@@ -133,16 +133,16 @@ func TestClient_WithRequestOption(t *testing.T) {
 		assert.Equal(t, "test-user-agent", r.Header.Get("User-Agent"))
 
 		// check basic auth
-		username, password, ok := r.BasicAuth()
+		clientID, clientSecret, ok := r.BasicAuth()
 		assert.True(t, ok)
-		assert.Equal(t, "test-username", username)
-		assert.Equal(t, "test-password", password)
+		assert.Equal(t, "test-client-id", clientID)
+		assert.Equal(t, "test-client-secret", clientSecret)
 
 		fmt.Fprint(w, successResponse) // nolint:errcheck
 	}))
 
 	req, err := client.NewRequest(ctx, http.MethodGet, "__/request-option", nil, []RequestOption{
-		WithRequestBasicAuth("test-username", "test-password"),
+		WithRequestBasicAuth("test-clientID", "test-clientSecret"),
 		WithRequestHeader("header-name", "header-value"),
 		WithRequestHeaders(map[string]string{
 			"headers-name": "headers-value",

--- a/request.go
+++ b/request.go
@@ -6,9 +6,9 @@ import (
 
 type RequestOption func(*http.Request) error
 
-func WithRequestBasicAuth(username, password string) RequestOption {
+func WithRequestBasicAuth(clientID, clientSecret string) RequestOption {
 	return func(req *http.Request) error {
-		req.SetBasicAuth(username, password)
+		req.SetBasicAuth(clientID, clientSecret)
 		return nil
 	}
 }


### PR DESCRIPTION
closed https://github.com/go-tapd/tapd/issues/71