### PR TITLE
make: add go-mod-tidy target and update lint dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,13 @@ init:
 	go install mvdan.cc/gofumpt@latest
 	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 
+.PHONY: go-mod-tidy
+go-mod-tidy:
+	go mod tidy -compat=1.23.0
+	@echo "✅ Go modules tidied"
+
 .PHONY: lint
-lint:
+lint: go-mod-tidy
 	golangci-lint run
 	@echo "✅ Linting completed"
 


### PR DESCRIPTION
- Add new go-mod-tidy target to ensure consistent module dependencies
- Update lint target to depend on go-mod-tidy, enforcing clean dependencies before linting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Added an automated step to tidy Go modules before running linting tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->