### PR TITLE
fix(api): correct casing of 'Cc' field to 'CC' for consistency

### DIFF
--- a/api_task.go
+++ b/api_task.go
@@ -47,7 +47,7 @@ type (
 		Modified          string        `json:"modified,omitempty"`         // 最后修改时间
 		Status            TaskStatus    `json:"status,omitempty"`           // 状态
 		Owner             string        `json:"owner,omitempty"`            // 任务当前处理人
-		Cc                string        `json:"cc,omitempty"`               // 抄送人
+		CC                string        `json:"cc,omitempty"`               // 抄送人
 		Begin             string        `json:"begin,omitempty"`            // 预计开始
 		Due               string        `json:"due,omitempty"`              // 预计结束
 		StoryID           string        `json:"story_id,omitempty"`         // 关联需求的ID


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the naming of a field related to carbon copy recipients in tasks. This change does not affect data format or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->