### PR TITLE
feat(auth): implement Personal Access Token (PAT) authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ see [features.md](features.md)
 
 ### API Service
 
+- Example of using the Basic Authentication API service:
+
 ```go
 package main
 
@@ -55,6 +57,36 @@ func main() {
 	}
 
 	log.Printf("labels: %+v", labels)
+}
+```
+
+- Example of using the Personal Access Token (PAT) API service:
+
+```go
+package main
+
+import (
+	"context"
+	"log"
+
+	"github.com/go-tapd/tapd"
+)
+
+func main() {
+	client, err := tapd.NewPATClient("your_pat_token")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// example: get stories
+	stories, _, err := client.StoryService.GetStories(context.Background(), &tapd.GetStoriesRequest{
+		WorkspaceID: tapd.Ptr(123456),
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Printf("stories: %+v", stories)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ import (
 )
 
 func main() {
-	client, err := tapd.NewPATClient("your_pat_token")
+	client, err := tapd.NewPATClient("your_access_token")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/client.go
+++ b/client.go
@@ -210,8 +210,10 @@ func (c *Client) NewRequest(ctx context.Context, method, path string, data any, 
 
 	// Apply request options
 	for _, opt := range opts {
-		if err := opt(req); err != nil {
-			return nil, err
+		if opt != nil {
+			if err := opt(req); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/client_options.go
+++ b/client_options.go
@@ -14,12 +14,23 @@ func WithBaseURL(urlStr string) ClientOption {
 // WithBasicAuth sets the clientID and clientSecret for the client
 func WithBasicAuth(clientID, clientSecret string) ClientOption {
 	return func(c *Client) error {
+		c.authType = authTypeBasic
 		c.clientID = clientID
 		c.clientSecret = clientSecret
 		return nil
 	}
 }
 
+// WithAccessToken sets the accessToken for the client
+func WithAccessToken(accessToken string) ClientOption {
+	return func(c *Client) error {
+		c.authType = authTypePAT
+		c.accessToken = accessToken
+		return nil
+	}
+}
+
+// WithUserAgent sets the userAgent for the client
 func WithUserAgent(userAgent string) ClientOption {
 	return func(c *Client) error {
 		c.userAgent = userAgent
@@ -27,6 +38,7 @@ func WithUserAgent(userAgent string) ClientOption {
 	}
 }
 
+// WithHTTPClient sets the httpClient for the client
 func WithHTTPClient(httpClient *http.Client) ClientOption {
 	return func(c *Client) error {
 		c.httpClient = httpClient

--- a/client_test.go
+++ b/client_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -59,11 +60,7 @@ func TestClient_BasicAuth(t *testing.T) {
 		assert.Equal(t, apiClientSecret, clientSecret)
 
 		// nolint:errcheck
-		fmt.Fprint(w, `{
-  "status": 1,
-  "data": {},
-  "info": "success"
-}`)
+		fmt.Fprint(w, successResponse)
 	}))
 	assert.Equal(t, authTypeBasic, client.authType)
 
@@ -86,11 +83,7 @@ func TestClient_PATAuth(t *testing.T) {
 		assert.Equal(t, "Bearer "+apiAccessToken, authHeader)
 
 		// nolint:errcheck
-		fmt.Fprint(w, `{
-  "status": 1,
-  "data": {},
-  "info": "success"
-}`)
+		fmt.Fprint(w, successResponse)
 	}))
 	t.Cleanup(srv.Close)
 
@@ -192,4 +185,96 @@ func TestClient_WithRequestOption(t *testing.T) {
 	resp, err := client.Do(req, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestClient_WithRequestOption_WithAuth(t *testing.T) {
+	var (
+		assertBasicAuthFunc = func(expectedClientID, expectedClientSecret string) func(t *testing.T, r *http.Request) {
+			return func(t *testing.T, r *http.Request) {
+				clientID, clientSecret, ok := r.BasicAuth()
+				assert.True(t, ok)
+				assert.Equal(t, expectedClientID, clientID)
+				assert.Equal(t, expectedClientSecret, clientSecret)
+			}
+		}
+		assertPATAuthFunc = func(expectedAccessToken string) func(t *testing.T, r *http.Request) {
+			return func(t *testing.T, r *http.Request) {
+				authHeader := r.Header.Get("Authorization")
+				assert.NotEmpty(t, authHeader)
+				assert.Equal(t, "Bearer "+expectedAccessToken, authHeader)
+			}
+		}
+
+		createClientBasicAuthFunc = func(clientID, clientSecret string) func(srv *httptest.Server) (*Client, error) {
+			return func(srv *httptest.Server) (*Client, error) {
+				return NewClient(clientID, clientSecret, WithBaseURL(srv.URL))
+			}
+		}
+		createClientPATAuthFunc = func(accessToken string) func(srv *httptest.Server) (*Client, error) {
+			return func(srv *httptest.Server) (*Client, error) {
+				return NewPATClient(accessToken, WithBaseURL(srv.URL))
+			}
+		}
+	)
+
+	tests := []struct {
+		name             string
+		createClientFunc func(srv *httptest.Server) (*Client, error)
+		requestOption    RequestOption
+		wantFunc         func(t *testing.T, r *http.Request)
+	}{
+		{
+			"client is created with Basic Auth, but request option is nil",
+			createClientBasicAuthFunc("client-a", "secret-a"),
+			nil,
+			assertBasicAuthFunc("client-a", "secret-a"),
+		},
+		{
+			"client is created with PAT Auth, but request option is nil",
+			createClientPATAuthFunc("access-token-a"),
+			nil,
+			assertPATAuthFunc("access-token-a"),
+		},
+		{
+			"Use Basic Auth when client is created with Basic Auth",
+			createClientBasicAuthFunc("client-a", "secret-a"),
+			WithRequestBasicAuth("client-b", "secret-b"),
+			assertBasicAuthFunc("client-b", "secret-b"),
+		},
+		{
+			"Use Basic Auth when client is created with PAT Auth",
+			createClientBasicAuthFunc("client-a", "secret-a"),
+			WithRequestAccessToken("access-token-b"),
+			assertPATAuthFunc("access-token-b"),
+		},
+		{
+			"Use PAT Auth when client is created with PAT Auth",
+			createClientPATAuthFunc("access-token-a"),
+			WithRequestAccessToken("access-token-b"),
+			assertPATAuthFunc("access-token-b"),
+		},
+		{
+			"Use PAT Auth when client is created with Basic Auth",
+			createClientPATAuthFunc("access-token-a"),
+			WithRequestBasicAuth("client-b", "secret-b"),
+			assertBasicAuthFunc("client-b", "secret-b"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				tt.wantFunc(t, r)
+				fmt.Fprint(w, successResponse) // nolint:errcheck
+			}))
+
+			client, err := tt.createClientFunc(srv)
+			require.NoError(t, err)
+
+			_, _, _ = client.StoryService.GetStories(
+				ctx, nil,
+				tt.requestOption,
+			)
+		})
+	}
 }

--- a/request.go
+++ b/request.go
@@ -8,7 +8,16 @@ type RequestOption func(*http.Request) error
 
 func WithRequestBasicAuth(clientID, clientSecret string) RequestOption {
 	return func(req *http.Request) error {
+		// Note: It just happens that the Header has the same name(Authorization), so the assignment can be overwritten.
 		req.SetBasicAuth(clientID, clientSecret)
+		return nil
+	}
+}
+
+func WithRequestAccessToken(accessToken string) RequestOption {
+	return func(req *http.Request) error {
+		// Note: It just happens that the Header has the same name(Authorization), so the assignment can be overwritten.
+		req.Header.Set("Authorization", "Bearer "+accessToken)
 		return nil
 	}
 }


### PR DESCRIPTION
closed https://github.com/go-tapd/tapd/issues/160

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Personal Access Token (PAT) authentication alongside Basic Authentication.
  - Enabled configuration of authentication type and access token when creating a client.
  - Introduced an option to set the Authorization header with a Bearer token on individual requests.

- **Bug Fixes**
  - Improved authentication header handling to correctly apply based on the selected authentication type.
  - Prevented potential errors by skipping nil request options during request preparation.

- **Tests**
  - Added tests to verify client behavior using PAT authentication.
  - Enhanced existing tests to validate authentication type settings and request-level authentication overrides.

- **Documentation**
  - Updated README with an example demonstrating PAT authentication usage.
  - Added comments clarifying new and existing authentication options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->