### PR TITLE
ci: support Go 1.25 and upgrade mod to 1.24.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     name: "go test"
     strategy:
       matrix:
-        go-version: [ 1.23.x, 1.24.x ]
+        go-version: [ 1.24.x, 1.25.x ]
         platform: [ ubuntu-latest, windows-latest, macos-latest ]
     runs-on: ${{ matrix.platform }}
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ init:
 
 .PHONY: go-mod-tidy
 go-mod-tidy:
-	go mod tidy -compat=1.23.0
+	go mod tidy -compat=1.24.0
 	@echo "✅ Go modules tidied"
 
 .PHONY: lint

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🚀 Go-Tapd-SDK
 
-![Supported Go Versions](https://img.shields.io/badge/Go-%3E%3D1.23-blue)
+![Supported Go Versions](https://img.shields.io/badge/Go-%3E%3D1.24-blue)
 [![Package Version](https://badgen.net/github/release/go-tapd/tapd/stable)](https://github.com/go-tapd/tapd/releases)
 [![GoDoc](https://pkg.go.dev/badge/github.com/go-tapd/tapd)](https://pkg.go.dev/github.com/go-tapd/tapd)
 [![codecov](https://codecov.io/gh/go-tapd/tapd/graph/badge.svg?token=QPTHZ5L9GT)](https://codecov.io/gh/go-tapd/tapd)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-tapd/tapd
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/davecgh/go-spew v1.1.1

--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
   "separateMajorMinor": true,
   "postUpdateOptions": ["gomodTidy"],
   "constraints": {
-    "go": "1.23.0"
+    "go": "1.24.0"
   },
   "packageRules": [
     {


### PR DESCRIPTION
- Update Go version in go.mod from 1.23.0 to 1.24.0
- Update Go version in Makefile from 1.23.0 to 1.24.0
- Update supported Go version in README.md from1.23 to 1.24
- Update Go version constraint in renovate.json from 1.23.0 to 1.24.0
- Update Go version matrix in GitHub Actions workflow from [1.23.x, 1.24.x] to [1.24.x, 1.25.x]