### PR TITLE
ci: ensure clean work tree before linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,3 +36,6 @@ jobs:
 
       - name: Run lint
         run: make lint
+
+      - name: check-clean-work
+        run: make check-clean-work-tree

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,4 +38,4 @@ jobs:
         run: make lint
 
       - name: check-clean-work
-        run: make check-clean-work-tree
+        run: make check-clean-work

--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,13 @@ lint-fix: lint
 test:
 	go test ./... -race
 	@echo "✅ Testing completed"
+
+.PHONY: check-clean-work
+check-clean-work:
+	@if ! git diff --quiet; then \
+	  echo; \
+	  echo 'Working tree is not clean, did you forget to run "git stash" or "git commit"?'; \
+	  echo; \
+	  git status; \
+	  exit 1; \
+	fi


### PR DESCRIPTION
- Add check-clean-work target to Makefile
- Incorporate check-clean-work step in GitHub Actions workflow