### PR TITLE
feat(wiki): add wiki API support

### DIFF
--- a/api_wiki.go
+++ b/api_wiki.go
@@ -69,6 +69,102 @@ type (
 		WorkspaceID         *int    `json:"workspace_id,omitempty"`         // [必须]项目ID
 		ParentWikiID        *string `json:"parent_wiki_id,omitempty"`       // 父wiki ID
 	}
+
+	WikiDrawioData struct {
+		ID     string `json:"id,omitempty"`     // drawio 数据ID
+		Values string `json:"values,omitempty"` // drawio XML 数据
+	}
+
+	GetWikiDrawioDataRequest struct {
+		ID          *int64  `url:"id,omitempty"`           // [必须]drawio 数据ID
+		WorkspaceID *int    `url:"workspace_id,omitempty"` // [必须]项目ID
+		Token       *string `url:"token,omitempty"`        // 验证用 token
+	}
+
+	WikiFollower struct {
+		ID          string `json:"id,omitempty"`           // id
+		WorkspaceID string `json:"workspace_id,omitempty"` // 项目ID
+		Created     string `json:"created,omitempty"`      // 创建时间
+		WikiID      string `json:"wiki_id,omitempty"`      // 关联的 wiki id
+		User        string `json:"user,omitempty"`         // 关注者昵称
+	}
+
+	GetWikiFollowersRequest struct {
+		ID          *int64         `url:"id,omitempty"`           // id
+		WorkspaceID *int           `url:"workspace_id,omitempty"` // [必须]项目ID
+		Created     *string        `url:"created,omitempty"`      // 创建时间，支持时间查询
+		WikiID      *int64         `url:"wiki_id,omitempty"`      // 关联的 wiki id
+		User        *string        `url:"user,omitempty"`         // 关注者昵称
+		Limit       *int           `url:"limit,omitempty"`        // 设置返回数量限制，默认为30，最大取200
+		Page        *int           `url:"page,omitempty"`         // 返回当前数量限制下第N页的数据，默认为1
+		Order       *Order         `url:"order,omitempty"`        // 排序规则
+		Fields      *Multi[string] `url:"fields,omitempty"`       // 设置获取的字段，多个字段间以','逗号隔开
+	}
+
+	GetWikiFollowersCountRequest struct {
+		ID          *int64  `url:"id,omitempty"`           // id
+		WorkspaceID *int    `url:"workspace_id,omitempty"` // [必须]项目ID
+		Created     *string `url:"created,omitempty"`      // 创建时间，支持时间查询
+		WikiID      *int64  `url:"wiki_id,omitempty"`      // 关联的 wiki id
+		User        *string `url:"user,omitempty"`         // 关注者昵称
+	}
+
+	WikiEntityPermission struct {
+		ID          string `json:"id,omitempty"`           // 记录ID
+		WorkspaceID string `json:"workspace_id,omitempty"` // 项目ID
+		EntryType   string `json:"entry_type,omitempty"`   // 固定值 wiki
+		TargetType  string `json:"target_type,omitempty"`  // 可访问的类型
+		TargetID    string `json:"target_id,omitempty"`    // 用户昵称或用户组ID
+		WikiID      string `json:"wiki_id,omitempty"`      // wiki ID
+	}
+
+	GetWikiEntityPermissionsRequest struct {
+		WorkspaceID *int           `url:"workspace_id,omitempty"` // [必须]项目ID
+		WikiID      *int64         `url:"wiki_id,omitempty"`      // [必须]wiki ID
+		TargetType  *string        `url:"target_type,omitempty"`  // 可访问的类型
+		TargetID    *string        `url:"target_id,omitempty"`    // 用户昵称或用户组ID
+		Limit       *int           `url:"limit,omitempty"`        // 设置返回数量限制，默认为30，最大取200
+		Page        *int           `url:"page,omitempty"`         // 返回当前数量限制下第N页的数据，默认为1
+		Order       *Order         `url:"order,omitempty"`        // 排序规则
+		Fields      *Multi[string] `url:"fields,omitempty"`       // 设置获取的字段，多个字段间以','逗号隔开
+	}
+
+	WikiTag struct {
+		Creator string `json:"creator,omitempty"` // 标签创建人 nick
+		Created string `json:"created,omitempty"` // 标签创建时间
+		WikiID  string `json:"wiki_id,omitempty"` // wiki id
+		Tag     string `json:"tag,omitempty"`     // 标签
+	}
+
+	GetWikiTagsRequest struct {
+		WorkspaceID *int    `url:"workspace_id,omitempty"` // [必须]项目ID
+		WikiID      *int64  `url:"wiki_id,omitempty"`      // wiki id，不传取项目下的所有 wiki
+		Tag         *string `url:"tag,omitempty"`          // 标签
+		Creator     *string `url:"creator,omitempty"`      // 标签创建人 nick
+		Created     *string `url:"created,omitempty"`      // 标签创建时间，支持时间查询
+		Limit       *int    `url:"limit,omitempty"`        // 设置返回数量限制，默认为30，最大取200
+		Page        *int    `url:"page,omitempty"`         // 返回当前数量限制下第N页的数据，默认为1
+		Order       *Order  `url:"order,omitempty"`        // 排序规则
+	}
+
+	GetWikiTagsCountRequest struct {
+		WorkspaceID *int    `url:"workspace_id,omitempty"` // [必须]项目ID
+		WikiID      *int64  `url:"wiki_id,omitempty"`      // wiki id，不传取项目下的所有 wiki
+		Tag         *string `url:"tag,omitempty"`          // 标签
+		Creator     *string `url:"creator,omitempty"`      // 标签创建人 nick
+		Created     *string `url:"created,omitempty"`      // 标签创建时间，支持时间查询
+	}
+
+	GetWikiAttachmentsCountRequest struct {
+		ID          *int64  `url:"id,omitempty"`           // id
+		Filename    *string `url:"filename,omitempty"`     // 文件名
+		Size        *int    `url:"size,omitempty"`         // 文件大小，字节
+		Owner       *string `url:"owner,omitempty"`        // 上传者
+		WorkspaceID *int    `url:"workspace_id,omitempty"` // [必须]项目ID
+		Created     *string `url:"created,omitempty"`      // 创建时间，支持时间查询
+		Modified    *string `url:"modified,omitempty"`     // 最后修改时间，支持时间查询
+		WikiID      *int64  `url:"wiki_id,omitempty"`      // 关联的 wiki id
+	}
 )
 
 // WikiService Wiki 服务。
@@ -94,6 +190,41 @@ type WikiService interface {
 	//
 	// https://open.tapd.cn/document/api-doc/API%E6%96%87%E6%A1%A3/api_reference/wiki/update_tapd_wiki.html
 	UpdateWiki(ctx context.Context, request *UpdateWikiRequest, opts ...RequestOption) (*Wiki, *Response, error)
+
+	// GetWikiDrawioData 获取 wiki drawio 数据
+	//
+	// https://open.tapd.cn/document/api-doc/API%E6%96%87%E6%A1%A3/api_reference/wiki/get_tapd_wikis_drawios.html
+	GetWikiDrawioData(ctx context.Context, request *GetWikiDrawioDataRequest, opts ...RequestOption) (*WikiDrawioData, *Response, error)
+
+	// GetWikiFollowers 获取 wiki 关注人数据
+	//
+	// https://open.tapd.cn/document/api-doc/API%E6%96%87%E6%A1%A3/api_reference/wiki/get_tapd_wikis_followers.html
+	GetWikiFollowers(ctx context.Context, request *GetWikiFollowersRequest, opts ...RequestOption) ([]*WikiFollower, *Response, error)
+
+	// GetWikiFollowersCount 获取 wiki 关注人数量
+	//
+	// https://open.tapd.cn/document/api-doc/API%E6%96%87%E6%A1%A3/api_reference/wiki/get_tapd_wikis_followers_count.html
+	GetWikiFollowersCount(ctx context.Context, request *GetWikiFollowersCountRequest, opts ...RequestOption) (int, *Response, error)
+
+	// GetWikiEntityPermissions 获取 wiki 可访问范围人员及用户组
+	//
+	// https://open.tapd.cn/document/api-doc/API%E6%96%87%E6%A1%A3/api_reference/wiki/get_tapd_wikis_entity_permissions.html
+	GetWikiEntityPermissions(ctx context.Context, request *GetWikiEntityPermissionsRequest, opts ...RequestOption) ([]*WikiEntityPermission, *Response, error)
+
+	// GetWikiTags 获取 wiki 标签信息
+	//
+	// https://open.tapd.cn/document/api-doc/API%E6%96%87%E6%A1%A3/api_reference/wiki/get_tapd_wikis_tags.html
+	GetWikiTags(ctx context.Context, request *GetWikiTagsRequest, opts ...RequestOption) ([]*WikiTag, *Response, error)
+
+	// GetWikiTagsCount 获取 wiki 标签信息数量
+	//
+	// https://open.tapd.cn/document/api-doc/API%E6%96%87%E6%A1%A3/api_reference/wiki/get_tapd_wikis_tags_count.html
+	GetWikiTagsCount(ctx context.Context, request *GetWikiTagsCountRequest, opts ...RequestOption) (int, *Response, error)
+
+	// GetWikiAttachmentsCount 获取 wiki 附件数量
+	//
+	// https://open.tapd.cn/document/api-doc/API%E6%96%87%E6%A1%A3/api_reference/wiki/get_tapd_wikis_attachments_count.html
+	GetWikiAttachmentsCount(ctx context.Context, request *GetWikiAttachmentsCountRequest, opts ...RequestOption) (int, *Response, error)
 }
 
 type wikiService struct {
@@ -185,4 +316,160 @@ func (s *wikiService) UpdateWiki(
 	}
 
 	return response.Wiki, resp, nil
+}
+
+func (s *wikiService) GetWikiDrawioData(
+	ctx context.Context, request *GetWikiDrawioDataRequest, opts ...RequestOption,
+) (*WikiDrawioData, *Response, error) {
+	req, err := s.client.NewRequest(ctx, http.MethodGet, "tapd_wikis_drawios", request, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var response struct {
+		StaticData *WikiDrawioData `json:"StaticData"`
+	}
+	resp, err := s.client.Do(req, &response)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return response.StaticData, resp, nil
+}
+
+func (s *wikiService) GetWikiFollowers(
+	ctx context.Context, request *GetWikiFollowersRequest, opts ...RequestOption,
+) ([]*WikiFollower, *Response, error) {
+	req, err := s.client.NewRequest(ctx, http.MethodGet, "tapd_wikis_followers", request, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return s.doWikiFollowers(req)
+}
+
+func (s *wikiService) GetWikiFollowersCount(
+	ctx context.Context, request *GetWikiFollowersCountRequest, opts ...RequestOption,
+) (int, *Response, error) {
+	req, err := s.client.NewRequest(ctx, http.MethodGet, "tapd_wikis_followers/count", request, opts)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	var response CountResponse
+	resp, err := s.client.Do(req, &response)
+	if err != nil {
+		return 0, resp, err
+	}
+
+	return response.Count, resp, nil
+}
+
+func (s *wikiService) GetWikiEntityPermissions(
+	ctx context.Context, request *GetWikiEntityPermissionsRequest, opts ...RequestOption,
+) ([]*WikiEntityPermission, *Response, error) {
+	req, err := s.client.NewRequest(ctx, http.MethodGet, "tapd_wikis_entity_permissions", request, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var items []struct {
+		EntityPermission *WikiEntityPermission `json:"EntityPermission"`
+	}
+	resp, err := s.client.Do(req, &items)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	permissions := make([]*WikiEntityPermission, 0, len(items))
+	for _, item := range items {
+		permissions = append(permissions, item.EntityPermission)
+	}
+
+	return permissions, resp, nil
+}
+
+func (s *wikiService) GetWikiTags(
+	ctx context.Context, request *GetWikiTagsRequest, opts ...RequestOption,
+) ([]*WikiTag, *Response, error) {
+	req, err := s.client.NewRequest(ctx, http.MethodGet, "tapd_wikis_tags", request, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var items []struct {
+		Tags *WikiTag `json:"Tags"`
+	}
+	resp, err := s.client.Do(req, &items)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	tags := make([]*WikiTag, 0, len(items))
+	for _, item := range items {
+		tags = append(tags, item.Tags)
+	}
+
+	return tags, resp, nil
+}
+
+func (s *wikiService) GetWikiTagsCount(
+	ctx context.Context, request *GetWikiTagsCountRequest, opts ...RequestOption,
+) (int, *Response, error) {
+	req, err := s.client.NewRequest(ctx, http.MethodGet, "tapd_wikis_tags/count", request, opts)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	var response CountResponse
+	resp, err := s.client.Do(req, &response)
+	if err != nil {
+		return 0, resp, err
+	}
+
+	return response.Count, resp, nil
+}
+
+func (s *wikiService) GetWikiAttachmentsCount(
+	ctx context.Context, request *GetWikiAttachmentsCountRequest, opts ...RequestOption,
+) (int, *Response, error) {
+	req, err := s.client.NewRequest(ctx, http.MethodGet, "tapd_wikis_attachments/count", request, opts)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	var response CountResponse
+	resp, err := s.client.Do(req, &response)
+	if err != nil {
+		return 0, resp, err
+	}
+
+	return response.Count, resp, nil
+}
+
+func (s *wikiService) doWikiFollowers(req *http.Request) ([]*WikiFollower, *Response, error) {
+	var items []map[string]*WikiFollower
+	resp, err := s.client.Do(req, &items)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	followers := make([]*WikiFollower, 0, len(items))
+	for _, item := range items {
+		for _, key := range []string{"WikiFollower", "WikiFollow", "Follower"} {
+			if follower := item[key]; follower != nil {
+				followers = append(followers, follower)
+				goto next
+			}
+		}
+		for _, follower := range item {
+			if follower != nil {
+				followers = append(followers, follower)
+				break
+			}
+		}
+	next:
+	}
+
+	return followers, resp, nil
 }

--- a/api_wiki.go
+++ b/api_wiki.go
@@ -1,0 +1,188 @@
+package tapd
+
+import (
+	"context"
+	"net/http"
+)
+
+type (
+	Wiki struct {
+		ID                  string `json:"id,omitempty"`                   // ID
+		Name                string `json:"name,omitempty"`                 // 标题
+		WorkspaceID         string `json:"workspace_id,omitempty"`         // 项目ID
+		Description         string `json:"description,omitempty"`          // 富文本
+		MarkdownDescription string `json:"markdown_description,omitempty"` // Markdown
+		IsRich              string `json:"is_rich,omitempty"`              // 是否富文本
+		ParentWikiID        string `json:"parent_wiki_id,omitempty"`       // 父wiki ID
+		Author              string `json:"author,omitempty"`               // 修改人
+		Creator             string `json:"creator,omitempty"`              // 创建人
+		Note                string `json:"note,omitempty"`                 // 备注
+		ViewCount           string `json:"view_count,omitempty"`           // 浏览量
+		Created             string `json:"created,omitempty"`              // 创建时间
+		Modified            string `json:"modified,omitempty"`             // 最后修改时间
+		Modifier            string `json:"modifier,omitempty"`             // 最后修改人
+	}
+
+	CreateWikiRequest struct {
+		Name                *string `json:"name,omitempty"`                 // [必须]标题
+		MarkdownDescription *string `json:"markdown_description,omitempty"` // Markdown
+		Description         *string `json:"description,omitempty"`          // 富文本
+		Creator             *string `json:"creator,omitempty"`              // [必须]创建人
+		Note                *string `json:"note,omitempty"`                 // 备注
+		WorkspaceID         *int    `json:"workspace_id,omitempty"`         // [必须]项目ID
+		ParentWikiID        *string `json:"parent_wiki_id,omitempty"`       // 父wiki ID
+	}
+
+	GetWikisRequest struct {
+		ID          *int64         `url:"id,omitempty"`           // id
+		Name        *string        `url:"name,omitempty"`         // 标题
+		Modifier    *string        `url:"modifier,omitempty"`     // 修改人
+		Creator     *string        `url:"creator,omitempty"`      // 创建人
+		Note        *string        `url:"note,omitempty"`         // 备注
+		ViewCount   *string        `url:"view_count,omitempty"`   // 浏览量
+		Created     *string        `url:"created,omitempty"`      // 创建时间，支持时间查询
+		Modified    *string        `url:"modified,omitempty"`     // 最后修改时间，支持时间查询
+		WorkspaceID *int           `url:"workspace_id,omitempty"` // [必须]项目ID
+		Limit       *int           `url:"limit,omitempty"`        // 设置返回数量限制，默认为30，最大取200
+		Page        *int           `url:"page,omitempty"`         // 返回当前数量限制下第N页的数据，默认为1
+		Order       *Order         `url:"order,omitempty"`        // 排序规则
+		Fields      *Multi[string] `url:"fields,omitempty"`       // 设置获取的字段，多个字段间以','逗号隔开
+	}
+
+	GetWikisCountRequest struct {
+		Name        *string `url:"name,omitempty"`         // 标题，支持模糊匹配
+		Modifier    *string `url:"modifier,omitempty"`     // 修改人
+		Creator     *string `url:"creator,omitempty"`      // 创建人
+		Note        *string `url:"note,omitempty"`         // 备注
+		ViewCount   *string `url:"view_count,omitempty"`   // 浏览量
+		Created     *string `url:"created,omitempty"`      // 创建时间，支持时间查询
+		Modified    *string `url:"modified,omitempty"`     // 最后修改时间，支持时间查询
+		WorkspaceID *int    `url:"workspace_id,omitempty"` // [必须]项目ID
+	}
+
+	UpdateWikiRequest struct {
+		ID                  *int64  `json:"id,omitempty"`                   // [必须]ID
+		Name                *string `json:"name,omitempty"`                 // 标题
+		MarkdownDescription *string `json:"markdown_description,omitempty"` // Markdown
+		Description         *string `json:"description,omitempty"`          // 富文本
+		Note                *string `json:"note,omitempty"`                 // 备注
+		WorkspaceID         *int    `json:"workspace_id,omitempty"`         // [必须]项目ID
+		ParentWikiID        *string `json:"parent_wiki_id,omitempty"`       // 父wiki ID
+	}
+)
+
+// WikiService Wiki 服务。
+//
+// https://open.tapd.cn/document/api-doc/API%E6%96%87%E6%A1%A3/api_reference/wiki/
+type WikiService interface {
+	// CreateWiki 创建 wiki
+	//
+	// https://open.tapd.cn/document/api-doc/API%E6%96%87%E6%A1%A3/api_reference/wiki/add_tapd_wiki.html
+	CreateWiki(ctx context.Context, request *CreateWikiRequest, opts ...RequestOption) (*Wiki, *Response, error)
+
+	// GetWikis 获取 wiki
+	//
+	// https://open.tapd.cn/document/api-doc/API%E6%96%87%E6%A1%A3/api_reference/wiki/get_tapd_wikis.html
+	GetWikis(ctx context.Context, request *GetWikisRequest, opts ...RequestOption) ([]*Wiki, *Response, error)
+
+	// GetWikisCount 获取 Wiki 数量
+	//
+	// https://open.tapd.cn/document/api-doc/API%E6%96%87%E6%A1%A3/api_reference/wiki/get_tapd_wikis_count.html
+	GetWikisCount(ctx context.Context, request *GetWikisCountRequest, opts ...RequestOption) (int, *Response, error)
+
+	// UpdateWiki 更新 wiki
+	//
+	// https://open.tapd.cn/document/api-doc/API%E6%96%87%E6%A1%A3/api_reference/wiki/update_tapd_wiki.html
+	UpdateWiki(ctx context.Context, request *UpdateWikiRequest, opts ...RequestOption) (*Wiki, *Response, error)
+}
+
+type wikiService struct {
+	client *Client
+}
+
+var _ WikiService = (*wikiService)(nil)
+
+func NewWikiService(client *Client) WikiService {
+	return &wikiService{
+		client: client,
+	}
+}
+
+func (s *wikiService) CreateWiki(
+	ctx context.Context, request *CreateWikiRequest, opts ...RequestOption,
+) (*Wiki, *Response, error) {
+	req, err := s.client.NewRequest(ctx, http.MethodPost, "tapd_wikis", request, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var response struct {
+		Wiki *Wiki `json:"Wiki"`
+	}
+	resp, err := s.client.Do(req, &response)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return response.Wiki, resp, nil
+}
+
+func (s *wikiService) GetWikis(
+	ctx context.Context, request *GetWikisRequest, opts ...RequestOption,
+) ([]*Wiki, *Response, error) {
+	req, err := s.client.NewRequest(ctx, http.MethodGet, "tapd_wikis", request, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var items []struct {
+		Wiki *Wiki `json:"Wiki"`
+	}
+	resp, err := s.client.Do(req, &items)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	wikis := make([]*Wiki, 0, len(items))
+	for _, item := range items {
+		wikis = append(wikis, item.Wiki)
+	}
+
+	return wikis, resp, nil
+}
+
+func (s *wikiService) GetWikisCount(
+	ctx context.Context, request *GetWikisCountRequest, opts ...RequestOption,
+) (int, *Response, error) {
+	req, err := s.client.NewRequest(ctx, http.MethodGet, "tapd_wikis/count", request, opts)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	var response CountResponse
+	resp, err := s.client.Do(req, &response)
+	if err != nil {
+		return 0, resp, err
+	}
+
+	return response.Count, resp, nil
+}
+
+func (s *wikiService) UpdateWiki(
+	ctx context.Context, request *UpdateWikiRequest, opts ...RequestOption,
+) (*Wiki, *Response, error) {
+	req, err := s.client.NewRequest(ctx, http.MethodPost, "tapd_wikis", request, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var response struct {
+		Wiki *Wiki `json:"Wiki"`
+	}
+	resp, err := s.client.Do(req, &response)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return response.Wiki, resp, nil
+}

--- a/api_wiki_test.go
+++ b/api_wiki_test.go
@@ -1,0 +1,174 @@
+package tapd
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWikiService_CreateWiki(t *testing.T) {
+	_, client := createServerClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/tapd_wikis", r.URL.Path)
+
+		var req CreateWikiRequest
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		assert.Equal(t, "test111", *req.Name)
+		assert.Equal(t, "## markdown", *req.MarkdownDescription)
+		assert.Equal(t, "xxxxxxx", *req.Description)
+		assert.Equal(t, "v_xuanfang", *req.Creator)
+		assert.Equal(t, "note", *req.Note)
+		assert.Equal(t, 10104801, *req.WorkspaceID)
+		assert.Equal(t, "0", *req.ParentWikiID)
+
+		_, _ = w.Write(loadData(t, "internal/testdata/api/wiki/create_wiki.json"))
+	}))
+
+	wiki, _, err := client.WikiService.CreateWiki(ctx, &CreateWikiRequest{
+		Name:                Ptr("test111"),
+		MarkdownDescription: Ptr("## markdown"),
+		Description:         Ptr("xxxxxxx"),
+		Creator:             Ptr("v_xuanfang"),
+		Note:                Ptr("note"),
+		WorkspaceID:         Ptr(10104801),
+		ParentWikiID:        Ptr("0"),
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "1210104801000043897", wiki.ID)
+	assert.Equal(t, "test111", wiki.Name)
+	assert.Equal(t, "10104801", wiki.WorkspaceID)
+	assert.Equal(t, "xxxxxxx", wiki.Description)
+	assert.Equal(t, "## markdown", wiki.MarkdownDescription)
+	assert.Equal(t, "1", wiki.IsRich)
+	assert.Equal(t, "0", wiki.ParentWikiID)
+	assert.Equal(t, "note", wiki.Note)
+	assert.Equal(t, "0", wiki.ViewCount)
+	assert.Equal(t, "2020-08-26 10:15:28", wiki.Created)
+	assert.Equal(t, "v_xuanfang", wiki.Creator)
+	assert.Equal(t, "2020-08-26 10:15:28", wiki.Modified)
+	assert.Equal(t, "v_xuanfang", wiki.Modifier)
+}
+
+func TestWikiService_GetWikis(t *testing.T) {
+	_, client := createServerClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/tapd_wikis", r.URL.Path)
+		assert.Equal(t, "1210104801000043827", r.URL.Query().Get("id"))
+		assert.Equal(t, "test", r.URL.Query().Get("name"))
+		assert.Equal(t, "dev", r.URL.Query().Get("modifier"))
+		assert.Equal(t, "dev", r.URL.Query().Get("creator"))
+		assert.Equal(t, "note", r.URL.Query().Get("note"))
+		assert.Equal(t, "4", r.URL.Query().Get("view_count"))
+		assert.Equal(t, "2020-08-25", r.URL.Query().Get("created"))
+		assert.Equal(t, "2020-08-26", r.URL.Query().Get("modified"))
+		assert.Equal(t, "10104801", r.URL.Query().Get("workspace_id"))
+		assert.Equal(t, "10", r.URL.Query().Get("limit"))
+		assert.Equal(t, "2", r.URL.Query().Get("page"))
+		assert.Equal(t, "created desc", r.URL.Query().Get("order"))
+		assert.Equal(t, "id,name,workspace_id", r.URL.Query().Get("fields"))
+
+		_, _ = w.Write(loadData(t, "internal/testdata/api/wiki/get_wikis.json"))
+	}))
+
+	wikis, _, err := client.WikiService.GetWikis(ctx, &GetWikisRequest{
+		ID:          Ptr[int64](1210104801000043827),
+		Name:        Ptr("test"),
+		Modifier:    Ptr("dev"),
+		Creator:     Ptr("dev"),
+		Note:        Ptr("note"),
+		ViewCount:   Ptr("4"),
+		Created:     Ptr("2020-08-25"),
+		Modified:    Ptr("2020-08-26"),
+		WorkspaceID: Ptr(10104801),
+		Limit:       Ptr(10),
+		Page:        Ptr(2),
+		Order:       NewOrder("created", OrderByDesc),
+		Fields:      NewMulti("id", "name", "workspace_id"),
+	})
+	assert.NoError(t, err)
+	assert.Len(t, wikis, 2)
+	assert.Equal(t, "1210104801000043827", wikis[0].ID)
+	assert.Equal(t, "test888", wikis[0].Name)
+	assert.Equal(t, "10104801", wikis[0].WorkspaceID)
+	assert.Equal(t, "", wikis[0].Description)
+	assert.Equal(t, "", wikis[0].MarkdownDescription)
+	assert.Equal(t, "0", wikis[0].IsRich)
+	assert.Equal(t, "0", wikis[0].ParentWikiID)
+	assert.Equal(t, "0", wikis[0].ViewCount)
+	assert.Equal(t, "2020-08-25 11:24:44", wikis[0].Created)
+	assert.Equal(t, "dev", wikis[0].Creator)
+	assert.Equal(t, "2020-08-25 11:24:44", wikis[0].Modified)
+	assert.Equal(t, "dev", wikis[0].Modifier)
+}
+
+func TestWikiService_GetWikisCount(t *testing.T) {
+	_, client := createServerClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/tapd_wikis/count", r.URL.Path)
+		assert.Equal(t, "test", r.URL.Query().Get("name"))
+		assert.Equal(t, "dev", r.URL.Query().Get("modifier"))
+		assert.Equal(t, "dev", r.URL.Query().Get("creator"))
+		assert.Equal(t, "note", r.URL.Query().Get("note"))
+		assert.Equal(t, "4", r.URL.Query().Get("view_count"))
+		assert.Equal(t, "2020-08-25", r.URL.Query().Get("created"))
+		assert.Equal(t, "2020-08-26", r.URL.Query().Get("modified"))
+		assert.Equal(t, "10104801", r.URL.Query().Get("workspace_id"))
+
+		_, _ = w.Write(loadData(t, "internal/testdata/api/wiki/get_wikis_count.json"))
+	}))
+
+	count, _, err := client.WikiService.GetWikisCount(ctx, &GetWikisCountRequest{
+		Name:        Ptr("test"),
+		Modifier:    Ptr("dev"),
+		Creator:     Ptr("dev"),
+		Note:        Ptr("note"),
+		ViewCount:   Ptr("4"),
+		Created:     Ptr("2020-08-25"),
+		Modified:    Ptr("2020-08-26"),
+		WorkspaceID: Ptr(10104801),
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 23, count)
+}
+
+func TestWikiService_UpdateWiki(t *testing.T) {
+	_, client := createServerClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/tapd_wikis", r.URL.Path)
+
+		var req UpdateWikiRequest
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		assert.Equal(t, int64(1210104801000043897), *req.ID)
+		assert.Equal(t, "test111", *req.Name)
+		assert.Equal(t, "## updated", *req.MarkdownDescription)
+		assert.Equal(t, "内容被更新", *req.Description)
+		assert.Equal(t, "note updated", *req.Note)
+		assert.Equal(t, 10104801, *req.WorkspaceID)
+		assert.Equal(t, "0", *req.ParentWikiID)
+
+		_, _ = w.Write(loadData(t, "internal/testdata/api/wiki/update_wiki.json"))
+	}))
+
+	wiki, _, err := client.WikiService.UpdateWiki(ctx, &UpdateWikiRequest{
+		ID:                  Ptr[int64](1210104801000043897),
+		Name:                Ptr("test111"),
+		MarkdownDescription: Ptr("## updated"),
+		Description:         Ptr("内容被更新"),
+		Note:                Ptr("note updated"),
+		WorkspaceID:         Ptr(10104801),
+		ParentWikiID:        Ptr("0"),
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "1210104801000043897", wiki.ID)
+	assert.Equal(t, "test111", wiki.Name)
+	assert.Equal(t, "10104801", wiki.WorkspaceID)
+	assert.Equal(t, "内容被更新", wiki.Description)
+	assert.Equal(t, "## updated", wiki.MarkdownDescription)
+	assert.Equal(t, "1", wiki.IsRich)
+	assert.Equal(t, "0", wiki.ParentWikiID)
+	assert.Equal(t, "1", wiki.ViewCount)
+	assert.Equal(t, "2020-08-26 10:30:11", wiki.Modified)
+	assert.Equal(t, "dev", wiki.Modifier)
+}

--- a/api_wiki_test.go
+++ b/api_wiki_test.go
@@ -172,3 +172,209 @@ func TestWikiService_UpdateWiki(t *testing.T) {
 	assert.Equal(t, "2020-08-26 10:30:11", wiki.Modified)
 	assert.Equal(t, "dev", wiki.Modifier)
 }
+
+func TestWikiService_GetWikiDrawioData(t *testing.T) {
+	_, client := createServerClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/tapd_wikis_drawios", r.URL.Path)
+		assert.Equal(t, "1100000000000001102", r.URL.Query().Get("id"))
+		assert.Equal(t, "10104801", r.URL.Query().Get("workspace_id"))
+		assert.Equal(t, "token", r.URL.Query().Get("token"))
+
+		_, _ = w.Write(loadData(t, "internal/testdata/api/wiki/get_wiki_drawio_data.json"))
+	}))
+
+	data, _, err := client.WikiService.GetWikiDrawioData(ctx, &GetWikiDrawioDataRequest{
+		ID:          Ptr[int64](1100000000000001102),
+		WorkspaceID: Ptr(10104801),
+		Token:       Ptr("token"),
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "1100000000000001102", data.ID)
+	assert.Contains(t, data.Values, "<mxGraphModel")
+}
+
+func TestWikiService_GetWikiFollowers(t *testing.T) {
+	_, client := createServerClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/tapd_wikis_followers", r.URL.Path)
+		assert.Equal(t, "1210104801000000001", r.URL.Query().Get("id"))
+		assert.Equal(t, "10104801", r.URL.Query().Get("workspace_id"))
+		assert.Equal(t, "2021-01-07", r.URL.Query().Get("created"))
+		assert.Equal(t, "1220358527000044697", r.URL.Query().Get("wiki_id"))
+		assert.Equal(t, "huanjinxie", r.URL.Query().Get("user"))
+		assert.Equal(t, "10", r.URL.Query().Get("limit"))
+		assert.Equal(t, "1", r.URL.Query().Get("page"))
+		assert.Equal(t, "created desc", r.URL.Query().Get("order"))
+		assert.Equal(t, "id,wiki_id,user", r.URL.Query().Get("fields"))
+
+		_, _ = w.Write(loadData(t, "internal/testdata/api/wiki/get_wiki_followers.json"))
+	}))
+
+	followers, _, err := client.WikiService.GetWikiFollowers(ctx, &GetWikiFollowersRequest{
+		ID:          Ptr[int64](1210104801000000001),
+		WorkspaceID: Ptr(10104801),
+		Created:     Ptr("2021-01-07"),
+		WikiID:      Ptr[int64](1220358527000044697),
+		User:        Ptr("huanjinxie"),
+		Limit:       Ptr(10),
+		Page:        Ptr(1),
+		Order:       NewOrder("created", OrderByDesc),
+		Fields:      NewMulti("id", "wiki_id", "user"),
+	})
+	assert.NoError(t, err)
+	assert.Len(t, followers, 2)
+	assert.Equal(t, "1210104801000000001", followers[0].ID)
+	assert.Equal(t, "10104801", followers[0].WorkspaceID)
+	assert.Equal(t, "1220358527000044697", followers[0].WikiID)
+	assert.Equal(t, "huanjinxie", followers[0].User)
+	assert.Equal(t, "2021-01-07 20:40:05", followers[0].Created)
+}
+
+func TestWikiService_GetWikiFollowersCount(t *testing.T) {
+	_, client := createServerClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/tapd_wikis_followers/count", r.URL.Path)
+		assert.Equal(t, "1210104801000000001", r.URL.Query().Get("id"))
+		assert.Equal(t, "10104801", r.URL.Query().Get("workspace_id"))
+		assert.Equal(t, "2021-01-07", r.URL.Query().Get("created"))
+		assert.Equal(t, "1220358527000044697", r.URL.Query().Get("wiki_id"))
+		assert.Equal(t, "huanjinxie", r.URL.Query().Get("user"))
+
+		_, _ = w.Write(loadData(t, "internal/testdata/api/wiki/get_wiki_followers_count.json"))
+	}))
+
+	count, _, err := client.WikiService.GetWikiFollowersCount(ctx, &GetWikiFollowersCountRequest{
+		ID:          Ptr[int64](1210104801000000001),
+		WorkspaceID: Ptr(10104801),
+		Created:     Ptr("2021-01-07"),
+		WikiID:      Ptr[int64](1220358527000044697),
+		User:        Ptr("huanjinxie"),
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 23, count)
+}
+
+func TestWikiService_GetWikiEntityPermissions(t *testing.T) {
+	_, client := createServerClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/tapd_wikis_entity_permissions", r.URL.Path)
+		assert.Equal(t, "10104801", r.URL.Query().Get("workspace_id"))
+		assert.Equal(t, "1210104801001897607", r.URL.Query().Get("wiki_id"))
+		assert.Equal(t, "nick", r.URL.Query().Get("target_type"))
+		assert.Equal(t, "jmyan", r.URL.Query().Get("target_id"))
+		assert.Equal(t, "10", r.URL.Query().Get("limit"))
+		assert.Equal(t, "1", r.URL.Query().Get("page"))
+		assert.Equal(t, "id asc", r.URL.Query().Get("order"))
+		assert.Equal(t, "id,wiki_id,target_id", r.URL.Query().Get("fields"))
+
+		_, _ = w.Write(loadData(t, "internal/testdata/api/wiki/get_wiki_entity_permissions.json"))
+	}))
+
+	permissions, _, err := client.WikiService.GetWikiEntityPermissions(ctx, &GetWikiEntityPermissionsRequest{
+		WorkspaceID: Ptr(10104801),
+		WikiID:      Ptr[int64](1210104801001897607),
+		TargetType:  Ptr("nick"),
+		TargetID:    Ptr("jmyan"),
+		Limit:       Ptr(10),
+		Page:        Ptr(1),
+		Order:       NewOrder("id", OrderByAsc),
+		Fields:      NewMulti("id", "wiki_id", "target_id"),
+	})
+	assert.NoError(t, err)
+	assert.Len(t, permissions, 2)
+	assert.Equal(t, "1210158241000001519", permissions[0].ID)
+	assert.Equal(t, "10158241", permissions[0].WorkspaceID)
+	assert.Equal(t, "wiki", permissions[0].EntryType)
+	assert.Equal(t, "role_id", permissions[0].TargetType)
+	assert.Equal(t, "1000000000000000002", permissions[0].TargetID)
+	assert.Equal(t, "1210158241000048769", permissions[0].WikiID)
+}
+
+func TestWikiService_GetWikiTags(t *testing.T) {
+	_, client := createServerClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/tapd_wikis_tags", r.URL.Path)
+		assert.Equal(t, "10104801", r.URL.Query().Get("workspace_id"))
+		assert.Equal(t, "1220358527000044697", r.URL.Query().Get("wiki_id"))
+		assert.Equal(t, "home", r.URL.Query().Get("tag"))
+		assert.Equal(t, "huanjinxie", r.URL.Query().Get("creator"))
+		assert.Equal(t, "2021-01-07", r.URL.Query().Get("created"))
+		assert.Equal(t, "10", r.URL.Query().Get("limit"))
+		assert.Equal(t, "1", r.URL.Query().Get("page"))
+		assert.Equal(t, "created desc", r.URL.Query().Get("order"))
+
+		_, _ = w.Write(loadData(t, "internal/testdata/api/wiki/get_wiki_tags.json"))
+	}))
+
+	tags, _, err := client.WikiService.GetWikiTags(ctx, &GetWikiTagsRequest{
+		WorkspaceID: Ptr(10104801),
+		WikiID:      Ptr[int64](1220358527000044697),
+		Tag:         Ptr("home"),
+		Creator:     Ptr("huanjinxie"),
+		Created:     Ptr("2021-01-07"),
+		Limit:       Ptr(10),
+		Page:        Ptr(1),
+		Order:       NewOrder("created", OrderByDesc),
+	})
+	assert.NoError(t, err)
+	assert.Len(t, tags, 2)
+	assert.Equal(t, "huanjinxie", tags[0].Creator)
+	assert.Equal(t, "2021-01-07 20:40:05", tags[0].Created)
+	assert.Equal(t, "1220358527000044697", tags[0].WikiID)
+	assert.Equal(t, "home", tags[0].Tag)
+}
+
+func TestWikiService_GetWikiTagsCount(t *testing.T) {
+	_, client := createServerClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/tapd_wikis_tags/count", r.URL.Path)
+		assert.Equal(t, "10104801", r.URL.Query().Get("workspace_id"))
+		assert.Equal(t, "1220358527000044697", r.URL.Query().Get("wiki_id"))
+		assert.Equal(t, "home", r.URL.Query().Get("tag"))
+		assert.Equal(t, "huanjinxie", r.URL.Query().Get("creator"))
+		assert.Equal(t, "2021-01-07", r.URL.Query().Get("created"))
+
+		_, _ = w.Write(loadData(t, "internal/testdata/api/wiki/get_wiki_tags_count.json"))
+	}))
+
+	count, _, err := client.WikiService.GetWikiTagsCount(ctx, &GetWikiTagsCountRequest{
+		WorkspaceID: Ptr(10104801),
+		WikiID:      Ptr[int64](1220358527000044697),
+		Tag:         Ptr("home"),
+		Creator:     Ptr("huanjinxie"),
+		Created:     Ptr("2021-01-07"),
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 2, count)
+}
+
+func TestWikiService_GetWikiAttachmentsCount(t *testing.T) {
+	_, client := createServerClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/tapd_wikis_attachments/count", r.URL.Path)
+		assert.Equal(t, "1210104801000028203", r.URL.Query().Get("id"))
+		assert.Equal(t, "README.md", r.URL.Query().Get("filename"))
+		assert.Equal(t, "1024", r.URL.Query().Get("size"))
+		assert.Equal(t, "anyechen", r.URL.Query().Get("owner"))
+		assert.Equal(t, "10104801", r.URL.Query().Get("workspace_id"))
+		assert.Equal(t, "2021-04-08", r.URL.Query().Get("created"))
+		assert.Equal(t, "2021-04-09", r.URL.Query().Get("modified"))
+		assert.Equal(t, "1210104801000017645", r.URL.Query().Get("wiki_id"))
+
+		_, _ = w.Write(loadData(t, "internal/testdata/api/wiki/get_wiki_attachments_count.json"))
+	}))
+
+	count, _, err := client.WikiService.GetWikiAttachmentsCount(ctx, &GetWikiAttachmentsCountRequest{
+		ID:          Ptr[int64](1210104801000028203),
+		Filename:    Ptr("README.md"),
+		Size:        Ptr(1024),
+		Owner:       Ptr("anyechen"),
+		WorkspaceID: Ptr(10104801),
+		Created:     Ptr("2021-04-08"),
+		Modified:    Ptr("2021-04-09"),
+		WikiID:      Ptr[int64](1210104801000017645),
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 23, count)
+}

--- a/client.go
+++ b/client.go
@@ -64,6 +64,7 @@ type Client struct {
 	SettingService    SettingService
 	TestService       TestService
 	BoardService      BoardService
+	WikiService       WikiService
 }
 
 // NewClient returns a new Tapd API client.
@@ -118,6 +119,7 @@ func newClient(opts ...ClientOption) (*Client, error) {
 	c.SettingService = NewSettingService(c)
 	c.TestService = NewTestService(c)
 	c.BoardService = NewBoardService(c)
+	c.WikiService = NewWikiService(c)
 
 	return c, nil
 }

--- a/features.md
+++ b/features.md
@@ -180,13 +180,13 @@ API 文档：https://open.tapd.cn/document/api-doc/API%E6%96%87%E6%A1%A3/
 - [x] 获取 wiki —— AI 实现，未人工验证
 - [x] 获取 Wiki 数量 —— AI 实现，未人工验证
 - [x] 更新 wiki —— AI 实现，未人工验证
-- [ ] 获取wiki drawio数据
-- [ ] 获取wiki关注人数据
-- [ ] 获取wiki关注人数量
-- [ ] 获取wiki可访问范围人员及用户组
-- [ ] 获取wiki标签信息
-- [ ] 获取wiki标签信息数量
-- [ ] 获取wiki附件数量
+- [x] 获取wiki drawio数据 —— AI 实现，未人工验证
+- [x] 获取wiki关注人数据 —— AI 实现，未人工验证
+- [x] 获取wiki关注人数量 —— AI 实现，未人工验证
+- [x] 获取wiki可访问范围人员及用户组 —— AI 实现，未人工验证
+- [x] 获取wiki标签信息 —— AI 实现，未人工验证
+- [x] 获取wiki标签信息数量 —— AI 实现，未人工验证
+- [x] 获取wiki附件数量 —— AI 实现，未人工验证
 
 ### 看板
 

--- a/features.md
+++ b/features.md
@@ -176,10 +176,10 @@ API 文档：https://open.tapd.cn/document/api-doc/API%E6%96%87%E6%A1%A3/
 
 ### Wiki
 
-- [ ] 创建 wiki
-- [ ] 获取 wiki
-- [ ] 获取 Wiki 数量
-- [ ] 更新 wiki
+- [x] 创建 wiki —— AI 实现，未人工验证
+- [x] 获取 wiki —— AI 实现，未人工验证
+- [x] 获取 Wiki 数量 —— AI 实现，未人工验证
+- [x] 更新 wiki —— AI 实现，未人工验证
 - [ ] 获取wiki drawio数据
 - [ ] 获取wiki关注人数据
 - [ ] 获取wiki关注人数量

--- a/internal/testdata/api/wiki/create_wiki.json
+++ b/internal/testdata/api/wiki/create_wiki.json
@@ -1,0 +1,21 @@
+{
+  "status": 1,
+  "data": {
+    "Wiki": {
+      "id": "1210104801000043897",
+      "name": "test111",
+      "workspace_id": "10104801",
+      "description": "xxxxxxx",
+      "markdown_description": "## markdown",
+      "is_rich": "1",
+      "parent_wiki_id": "0",
+      "note": "note",
+      "view_count": "0",
+      "created": "2020-08-26 10:15:28",
+      "creator": "v_xuanfang",
+      "modified": "2020-08-26 10:15:28",
+      "modifier": "v_xuanfang"
+    }
+  },
+  "info": "success"
+}

--- a/internal/testdata/api/wiki/get_wiki_attachments_count.json
+++ b/internal/testdata/api/wiki/get_wiki_attachments_count.json
@@ -1,0 +1,7 @@
+{
+  "status": 1,
+  "data": {
+    "count": 23
+  },
+  "info": "success"
+}

--- a/internal/testdata/api/wiki/get_wiki_drawio_data.json
+++ b/internal/testdata/api/wiki/get_wiki_drawio_data.json
@@ -1,0 +1,10 @@
+{
+  "status": 1,
+  "data": {
+    "StaticData": {
+      "id": "1100000000000001102",
+      "values": "<mxGraphModel><root><mxCell id=\"0\" /></root></mxGraphModel>"
+    }
+  },
+  "info": "success"
+}

--- a/internal/testdata/api/wiki/get_wiki_entity_permissions.json
+++ b/internal/testdata/api/wiki/get_wiki_entity_permissions.json
@@ -1,0 +1,26 @@
+{
+  "status": 1,
+  "data": [
+    {
+      "EntityPermission": {
+        "id": "1210158241000001519",
+        "workspace_id": "10158241",
+        "entry_type": "wiki",
+        "target_type": "role_id",
+        "target_id": "1000000000000000002",
+        "wiki_id": "1210158241000048769"
+      }
+    },
+    {
+      "EntityPermission": {
+        "id": "1210158241000001513",
+        "workspace_id": "10158241",
+        "entry_type": "wiki",
+        "target_type": "nick",
+        "target_id": "jmyan",
+        "wiki_id": "1210158241000048769"
+      }
+    }
+  ],
+  "info": "success"
+}

--- a/internal/testdata/api/wiki/get_wiki_followers.json
+++ b/internal/testdata/api/wiki/get_wiki_followers.json
@@ -1,0 +1,24 @@
+{
+  "status": 1,
+  "data": [
+    {
+      "WikiFollower": {
+        "id": "1210104801000000001",
+        "workspace_id": "10104801",
+        "created": "2021-01-07 20:40:05",
+        "wiki_id": "1220358527000044697",
+        "user": "huanjinxie"
+      }
+    },
+    {
+      "WikiFollow": {
+        "id": "1210104801000000002",
+        "workspace_id": "10104801",
+        "created": "2021-01-08 20:40:05",
+        "wiki_id": "1220358527000044697",
+        "user": "dev"
+      }
+    }
+  ],
+  "info": "success"
+}

--- a/internal/testdata/api/wiki/get_wiki_followers_count.json
+++ b/internal/testdata/api/wiki/get_wiki_followers_count.json
@@ -1,0 +1,7 @@
+{
+  "status": 1,
+  "data": {
+    "count": 23
+  },
+  "info": "success"
+}

--- a/internal/testdata/api/wiki/get_wiki_tags.json
+++ b/internal/testdata/api/wiki/get_wiki_tags.json
@@ -1,0 +1,22 @@
+{
+  "status": 1,
+  "data": [
+    {
+      "Tags": {
+        "creator": "huanjinxie",
+        "created": "2021-01-07 20:40:05",
+        "wiki_id": "1220358527000044697",
+        "tag": "home"
+      }
+    },
+    {
+      "Tags": {
+        "creator": "huanjinxie",
+        "created": "2021-01-07 20:40:05",
+        "wiki_id": "1220358527000044697",
+        "tag": "test"
+      }
+    }
+  ],
+  "info": "success"
+}

--- a/internal/testdata/api/wiki/get_wiki_tags_count.json
+++ b/internal/testdata/api/wiki/get_wiki_tags_count.json
@@ -1,0 +1,7 @@
+{
+  "status": 1,
+  "data": {
+    "count": 2
+  },
+  "info": "success"
+}

--- a/internal/testdata/api/wiki/get_wikis.json
+++ b/internal/testdata/api/wiki/get_wikis.json
@@ -1,0 +1,40 @@
+{
+  "status": 1,
+  "data": [
+    {
+      "Wiki": {
+        "id": "1210104801000043827",
+        "name": "test888",
+        "workspace_id": "10104801",
+        "description": "",
+        "markdown_description": "",
+        "is_rich": "0",
+        "parent_wiki_id": "0",
+        "note": "",
+        "view_count": "0",
+        "created": "2020-08-25 11:24:44",
+        "creator": "dev",
+        "modified": "2020-08-25 11:24:44",
+        "modifier": "dev"
+      }
+    },
+    {
+      "Wiki": {
+        "id": "1210104801000043823",
+        "name": "test888",
+        "workspace_id": "10104801",
+        "description": "",
+        "markdown_description": "wfwwf4",
+        "is_rich": "0",
+        "parent_wiki_id": "0",
+        "note": "",
+        "view_count": "4",
+        "created": "2020-08-25 11:22:20",
+        "creator": "dev",
+        "modified": "2020-08-25 15:39:05",
+        "modifier": "dev"
+      }
+    }
+  ],
+  "info": "success"
+}

--- a/internal/testdata/api/wiki/get_wikis_count.json
+++ b/internal/testdata/api/wiki/get_wikis_count.json
@@ -1,0 +1,7 @@
+{
+  "status": 1,
+  "data": {
+    "count": 23
+  },
+  "info": "success"
+}

--- a/internal/testdata/api/wiki/update_wiki.json
+++ b/internal/testdata/api/wiki/update_wiki.json
@@ -1,0 +1,21 @@
+{
+  "status": 1,
+  "data": {
+    "Wiki": {
+      "id": "1210104801000043897",
+      "name": "test111",
+      "workspace_id": "10104801",
+      "description": "内容被更新",
+      "markdown_description": "## updated",
+      "is_rich": "1",
+      "parent_wiki_id": "0",
+      "note": "note updated",
+      "view_count": "1",
+      "created": "2020-08-26 10:15:28",
+      "creator": "v_xuanfang",
+      "modified": "2020-08-26 10:30:11",
+      "modifier": "dev"
+    }
+  },
+  "info": "success"
+}


### PR DESCRIPTION
## Summary
Add Wiki API coverage for TAPD wiki resources, including base wiki CRUD-style endpoints and related drawio, follower, permission, tag, and attachment count queries.

## Changes
- Add WikiService with methods for wiki creation, listing, counts, updates, drawio data, followers, entity permissions, tags, and attachment counts
- Wire WikiService into Client
- Add unit tests and fixtures for all Wiki endpoints
- Mark the Wiki section in features.md as AI implemented and not manually verified

## Motivation
- Complete the Wiki section of the TAPD API coverage tracked in features.md

## Testing
- GOCACHE=/private/tmp/go-build-cache-tapd go test . -run 'TestWikiService_' -v
- GOCACHE=/private/tmp/go-build-cache-tapd go test ./... -race
- git diff --check