### PR TITLE
feat(source): add source code commit APIs

### DIFF
--- a/api_source.go
+++ b/api_source.go
@@ -1,0 +1,205 @@
+package tapd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+)
+
+// StringNumber 兼容官方响应中同一字段可能返回字符串或数字的 ID。
+type StringNumber string
+
+func (s *StringNumber) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		*s = ""
+		return nil
+	}
+
+	var value string
+	if err := json.Unmarshal(data, &value); err == nil {
+		*s = StringNumber(value)
+		return nil
+	}
+
+	var number json.Number
+	if err := json.Unmarshal(data, &number); err != nil {
+		return err
+	}
+
+	*s = StringNumber(number.String())
+
+	return nil
+}
+
+func (s StringNumber) String() string {
+	return string(s)
+}
+
+// CodeCommitRelatedType 源码提交关联类型。
+type CodeCommitRelatedType string
+
+const (
+	CodeCommitRelatedTypeAll        CodeCommitRelatedType = "all"
+	CodeCommitRelatedTypeBranch     CodeCommitRelatedType = "branch"
+	CodeCommitRelatedTypeSourceCode CodeCommitRelatedType = "source_code"
+)
+
+type (
+	AddCodeCommitInfoRequest struct {
+		WorkspaceID *int      `json:"workspace_id,omitempty"` // [必须]项目ID
+		CommitID    *string   `json:"commit_id,omitempty"`    // [必须]提交ID
+		Author      *string   `json:"author,omitempty"`       // [必须]代码提交人
+		Message     *string   `json:"message,omitempty"`      // [必须]提交信息
+		Files       *[]string `json:"files,omitempty"`        // [必须]变更文件
+		Repo        *string   `json:"repo,omitempty"`         // [必须]仓库名
+		RepoID      *string   `json:"repo_id,omitempty"`      // [必须]仓库ID
+		CommitTime  *string   `json:"commit_time,omitempty"`  // [必须]提交时间
+		GitEnv      *string   `json:"git_env,omitempty"`      // 信息来源，github、gitlab、svn、p4 等
+		RepoURL     *string   `json:"repo_url,omitempty"`     // 仓库链接
+		CommitURL   *string   `json:"commit_url,omitempty"`   // 提交链接
+	}
+
+	GetCodeCommitInfosRequest struct {
+		WorkspaceID *int                   `url:"workspace_id,omitempty"` // [必须]项目ID
+		Type        *EntityType            `url:"type,omitempty"`         // [必须]TAPD业务对象类型，story、bug、task
+		ObjectID    *int64                 `url:"object_id,omitempty"`    // [必须]TAPD业务对象ID
+		CommitTime  *string                `url:"commit_time,omitempty"`  // 提交时间查询条件
+		RelatedType *CodeCommitRelatedType `url:"related_type,omitempty"` // 关联类型，all、branch、source_code
+		Limit       *int                   `url:"limit,omitempty"`        // 返回数量限制，默认30，最大200
+		Page        *int                   `url:"page,omitempty"`         // 当前页，默认1
+	}
+
+	GetCommitObjectsRequest struct {
+		WorkspaceID *int           `url:"workspace_id,omitempty"` // [必须]项目ID
+		CommitID    *Multi[string] `url:"commit_id,omitempty"`    // [必须]提交ID，多个以逗号分隔
+		EntityType  *EntityType    `url:"entity_type,omitempty"`  // [必须]业务对象类型，story、bug、task
+		SCMType     *string        `url:"scm_type,omitempty"`     // 来源类型
+		Limit       *int           `url:"limit,omitempty"`        // 返回数量限制，默认30，最大200
+		Page        *int           `url:"page,omitempty"`         // 当前页，默认1
+		Order       *Order         `url:"order,omitempty"`        // 排序规则
+		Fields      *Multi[string] `url:"fields,omitempty"`       // 返回字段，多个以逗号分隔
+	}
+
+	CodeCommitInfo struct {
+		ID              string                   `json:"id,omitempty"`                // 记录ID
+		HookUserName    string                   `json:"hook_user_name,omitempty"`    // 代码提交人
+		CommitID        string                   `json:"commit_id,omitempty"`         // 提交ID
+		UserName        string                   `json:"user_name,omitempty"`         // 关联用户
+		UserID          string                   `json:"user_id,omitempty"`           // 关联用户ID
+		WorkspaceID     StringNumber             `json:"workspace_id,omitempty"`      // 项目ID
+		Message         string                   `json:"message,omitempty"`           // 提交信息
+		Path            string                   `json:"path,omitempty"`              // 提交地址
+		WebURL          string                   `json:"web_url,omitempty"`           // 仓库地址
+		HookProjectName string                   `json:"hook_project_name,omitempty"` // 仓库名
+		CommitTime      string                   `json:"commit_time,omitempty"`       // 提交时间
+		Created         string                   `json:"created,omitempty"`           // 创建时间
+		Ref             string                   `json:"ref,omitempty"`               // 分支引用
+		RefStatus       string                   `json:"ref_status,omitempty"`        // 分支状态
+		GitEnv          string                   `json:"git_env,omitempty"`           // 信息来源
+		FileCommit      string                   `json:"file_commit,omitempty"`       // 变更文件
+		RepoID          string                   `json:"repo_id,omitempty"`           // 仓库ID
+		BranchID        string                   `json:"branch_id,omitempty"`         // 分支ID
+		FileSort        map[string]int           `json:"file_sort,omitempty"`         // 文件排序
+		Related         []*CodeCommitInfoRelated `json:"related,omitempty"`           // 关联结果
+	}
+
+	CodeCommitInfoRelated struct {
+		Type        EntityType   `json:"type,omitempty"`         // 业务对象类型
+		ObjectID    string       `json:"object_id,omitempty"`    // 业务对象ID
+		CommitID    string       `json:"commit_id,omitempty"`    // 提交记录ID
+		WorkspaceID StringNumber `json:"workspace_id,omitempty"` // 项目ID
+		Code        string       `json:"code,omitempty"`         // 关联结果代码
+	}
+
+	CommitObject struct {
+		Story *Story `json:"Story,omitempty"` // 关联需求
+		Bug   *Bug   `json:"Bug,omitempty"`   // 关联缺陷
+		Task  *Task  `json:"Task,omitempty"`  // 关联任务
+	}
+)
+
+type SourceService interface {
+	// AddCodeCommitInfo 保存Commit提交数据
+	//
+	// https://open.tapd.cn/document/api-doc/API%E6%96%87%E6%A1%A3/api_reference/source/add_code_commit_info.html
+	AddCodeCommitInfo(
+		ctx context.Context, request *AddCodeCommitInfoRequest, opts ...RequestOption,
+	) (*CodeCommitInfo, *Response, error)
+
+	// GetCodeCommitInfos 获取GIT关联提交数据(GitCommit)
+	//
+	// https://open.tapd.cn/document/api-doc/API%E6%96%87%E6%A1%A3/api_reference/source/get_code_commit_infos.html
+	GetCodeCommitInfos(
+		ctx context.Context, request *GetCodeCommitInfosRequest, opts ...RequestOption,
+	) ([]*CodeCommitInfo, *Response, error)
+
+	// GetCommitObjects 获取指定commit关联的业务对象
+	//
+	// https://open.tapd.cn/document/api-doc/API%E6%96%87%E6%A1%A3/api_reference/source/get_commit_objects.html
+	GetCommitObjects(
+		ctx context.Context, request *GetCommitObjectsRequest, opts ...RequestOption,
+	) ([]*CommitObject, *Response, error)
+}
+
+type sourceService struct {
+	client *Client
+}
+
+var _ SourceService = (*sourceService)(nil)
+
+func NewSourceService(client *Client) SourceService {
+	return &sourceService{
+		client: client,
+	}
+}
+
+func (s *sourceService) AddCodeCommitInfo(
+	ctx context.Context, request *AddCodeCommitInfoRequest, opts ...RequestOption,
+) (*CodeCommitInfo, *Response, error) {
+	req, err := s.client.NewRequest(ctx, http.MethodPost, "code_commit_infos", request, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	response := new(CodeCommitInfo)
+	resp, err := s.client.Do(req, response)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return response, resp, nil
+}
+
+func (s *sourceService) GetCodeCommitInfos(
+	ctx context.Context, request *GetCodeCommitInfosRequest, opts ...RequestOption,
+) ([]*CodeCommitInfo, *Response, error) {
+	req, err := s.client.NewRequest(ctx, http.MethodGet, "code_commit_infos", request, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	infos := make([]*CodeCommitInfo, 0)
+	resp, err := s.client.Do(req, &infos)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return infos, resp, nil
+}
+
+func (s *sourceService) GetCommitObjects(
+	ctx context.Context, request *GetCommitObjectsRequest, opts ...RequestOption,
+) ([]*CommitObject, *Response, error) {
+	req, err := s.client.NewRequest(ctx, http.MethodGet, "code_commit_objects/workitems", request, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	objects := make([]*CommitObject, 0)
+	resp, err := s.client.Do(req, &objects)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return objects, resp, nil
+}

--- a/api_source_test.go
+++ b/api_source_test.go
@@ -1,0 +1,109 @@
+package tapd
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSourceService_AddCodeCommitInfo(t *testing.T) {
+	_, client := createServerClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/code_commit_infos", r.URL.Path)
+
+		var req AddCodeCommitInfoRequest
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		assert.Equal(t, 20375571, *req.WorkspaceID)
+		assert.Equal(t, "zxxxxx", *req.CommitID)
+		assert.Equal(t, "terrysxu", *req.Author)
+		assert.Equal(t, "--story=854927829 ASA-c2s", *req.Message)
+		assert.Equal(t, []string{"U xxx.php", "A xxx.js", "M xxx.html"}, *req.Files)
+		assert.Equal(t, "repos/xxx_proj", *req.Repo)
+		assert.Equal(t, "abcd1234-avcd-1234-avcd-1234abcdefgh", *req.RepoID)
+		assert.Equal(t, "2019-07-22 19:11:11", *req.CommitTime)
+
+		_, _ = w.Write(loadData(t, "internal/testdata/api/source/add_code_commit_info.json"))
+	}))
+
+	info, _, err := client.SourceService.AddCodeCommitInfo(ctx, &AddCodeCommitInfoRequest{
+		WorkspaceID: Ptr(20375571),
+		CommitID:    Ptr("zxxxxx"),
+		Author:      Ptr("terrysxu"),
+		Message:     Ptr("--story=854927829 ASA-c2s"),
+		Files:       &[]string{"U xxx.php", "A xxx.js", "M xxx.html"},
+		Repo:        Ptr("repos/xxx_proj"),
+		RepoID:      Ptr("abcd1234-avcd-1234-avcd-1234abcdefgh"),
+		CommitTime:  Ptr("2019-07-22 19:11:11"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "1020375571000321465", info.ID)
+	assert.Equal(t, "20375571", info.WorkspaceID.String())
+	assert.Equal(t, "zxxxxx", info.CommitID)
+	require.Len(t, info.Related, 1)
+	assert.Equal(t, EntityTypeStory, info.Related[0].Type)
+	assert.Equal(t, "1020375571854927829", info.Related[0].ObjectID)
+}
+
+func TestSourceService_GetCodeCommitInfos(t *testing.T) {
+	_, client := createServerClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/code_commit_infos", r.URL.Path)
+		assert.Equal(t, "20358374", r.URL.Query().Get("workspace_id"))
+		assert.Equal(t, "story", r.URL.Query().Get("type"))
+		assert.Equal(t, "1020358374854843133", r.URL.Query().Get("object_id"))
+		assert.Equal(t, "source_code", r.URL.Query().Get("related_type"))
+		assert.Equal(t, "50", r.URL.Query().Get("limit"))
+		assert.Equal(t, "2", r.URL.Query().Get("page"))
+
+		_, _ = w.Write(loadData(t, "internal/testdata/api/source/get_code_commit_infos.json"))
+	}))
+
+	infos, _, err := client.SourceService.GetCodeCommitInfos(ctx, &GetCodeCommitInfosRequest{
+		WorkspaceID: Ptr(20358374),
+		Type:        Ptr(EntityTypeStory),
+		ObjectID:    Ptr[int64](1020358374854843133),
+		RelatedType: Ptr(CodeCommitRelatedTypeSourceCode),
+		Limit:       Ptr(50),
+		Page:        Ptr(2),
+	})
+	require.NoError(t, err)
+	require.Len(t, infos, 1)
+	assert.Equal(t, "1020358374000262989", infos[0].ID)
+	assert.Equal(t, "20358374", infos[0].WorkspaceID.String())
+	assert.Equal(t, "111", infos[0].CommitID)
+	assert.Equal(t, 0, infos[0].FileSort["tapd_interface_test/cases/cloud/company_settings.jmx"])
+}
+
+func TestSourceService_GetCommitObjects(t *testing.T) {
+	_, client := createServerClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/code_commit_objects/workitems", r.URL.Path)
+		assert.Equal(t, "20355782", r.URL.Query().Get("workspace_id"))
+		assert.Equal(t, "7b0645c6a467a502fe1d3b678fea8bdf2890aa8d,047e5764c392bef48fd0e4176c147c7c30a9f32a", r.URL.Query().Get("commit_id"))
+		assert.Equal(t, "task", r.URL.Query().Get("entity_type"))
+		assert.Equal(t, "gitlab", r.URL.Query().Get("scm_type"))
+		assert.Equal(t, "id,name,status", r.URL.Query().Get("fields"))
+
+		_, _ = w.Write(loadData(t, "internal/testdata/api/source/get_commit_objects.json"))
+	}))
+
+	objects, _, err := client.SourceService.GetCommitObjects(ctx, &GetCommitObjectsRequest{
+		WorkspaceID: Ptr(20355782),
+		CommitID: NewMulti(
+			"7b0645c6a467a502fe1d3b678fea8bdf2890aa8d",
+			"047e5764c392bef48fd0e4176c147c7c30a9f32a",
+		),
+		EntityType: Ptr(EntityTypeTask),
+		SCMType:    Ptr("gitlab"),
+		Fields:     NewMulti("id", "name", "status"),
+	})
+	require.NoError(t, err)
+	require.Len(t, objects, 1)
+	require.NotNil(t, objects[0].Task)
+	assert.Equal(t, "1020355782500602947", objects[0].Task.ID)
+	assert.Equal(t, "666", objects[0].Task.Name)
+	assert.Equal(t, TaskStatusOpen, objects[0].Task.Status)
+}

--- a/client.go
+++ b/client.go
@@ -66,6 +66,7 @@ type Client struct {
 	BoardService      BoardService
 	WikiService       WikiService
 	ReleaseService    ReleaseService
+	SourceService     SourceService
 }
 
 // NewClient returns a new Tapd API client.
@@ -122,6 +123,7 @@ func newClient(opts ...ClientOption) (*Client, error) {
 	c.BoardService = NewBoardService(c)
 	c.WikiService = NewWikiService(c)
 	c.ReleaseService = NewReleaseService(c)
+	c.SourceService = NewSourceService(c)
 
 	return c, nil
 }

--- a/features.md
+++ b/features.md
@@ -170,9 +170,9 @@ API 文档：https://open.tapd.cn/document/api-doc/API%E6%96%87%E6%A1%A3/
 
 ### 源码
 
-- [ ] 保存Commit提交数据
-- [ ] 获取GIT关联提交数据(GitCommit)
-- [ ] 获取指定commit关联的TAPD对象（需求、任务、缺陷）
+- [x] 保存Commit提交数据 —— AI 实现，未人工验证
+- [x] 获取GIT关联提交数据(GitCommit) —— AI 实现，未人工验证
+- [x] 获取指定commit关联的TAPD对象（需求、任务、缺陷） —— AI 实现，未人工验证
 
 ### Wiki
 

--- a/internal/testdata/api/source/add_code_commit_info.json
+++ b/internal/testdata/api/source/add_code_commit_info.json
@@ -1,0 +1,29 @@
+{
+  "status": 1,
+  "data": {
+    "id": "1020375571000321465",
+    "hook_user_name": "terrysxu",
+    "commit_id": "zxxxxx",
+    "user_name": "",
+    "workspace_id": 20375571,
+    "message": "--story=854927829 ASA-c2s",
+    "path": "",
+    "web_url": "",
+    "hook_project_name": "repos/xxx_proj",
+    "commit_time": "2019-07-22 19:11:11 +0800 (Mon, 22 Jul 2019)",
+    "ref": "",
+    "git_env": "CodeGit",
+    "file_commit": "{\"U\":[\"xxx.php\"],\"A\":[\"xxx.js\"],\"M\":[\"xxx.html\"]}",
+    "repo_id": "abcd1234-avcd-1234-avcd-1234abcdefgh",
+    "related": [
+      {
+        "type": "story",
+        "object_id": "1020375571854927829",
+        "commit_id": "1020375571000321465",
+        "workspace_id": 20375571,
+        "code": "SUCCESS"
+      }
+    ]
+  },
+  "info": "success"
+}

--- a/internal/testdata/api/source/get_code_commit_infos.json
+++ b/internal/testdata/api/source/get_code_commit_infos.json
@@ -1,0 +1,29 @@
+{
+  "status": 1,
+  "data": [
+    {
+      "id": "1020358374000262989",
+      "user_name": "jeffjffang",
+      "user_id": "2071532707",
+      "hook_user_name": "jeffjffang",
+      "commit_id": "111",
+      "workspace_id": "20358374",
+      "message": "--story=1020358374854843133 SMARTCOMMIT #fix 111222",
+      "path": "http://git.code.oa.com/TAPDG/tapd_test/commit/047e5764c392bef48fd0e4176c147c7c30a9f32a",
+      "web_url": "http://git.code.oa.com/TAPDG/tapd_test",
+      "hook_project_name": "tapd_test",
+      "commit_time": "2019-08-26 15:57:04",
+      "created": "2020-11-30 14:31:29",
+      "ref": "refs/heads/master",
+      "ref_status": "0",
+      "git_env": "CodeGit",
+      "file_commit": "{\"A\":[],\"M\":[\"tapd_interface_test/cases/cloud/company_settings.jmx\"],\"R\":[]}",
+      "repo_id": "20045801",
+      "branch_id": "20045801/refs/heads/master",
+      "file_sort": {
+        "tapd_interface_test/cases/cloud/company_settings.jmx": 0
+      }
+    }
+  ],
+  "info": "success"
+}

--- a/internal/testdata/api/source/get_commit_objects.json
+++ b/internal/testdata/api/source/get_commit_objects.json
@@ -1,0 +1,33 @@
+{
+  "status": 1,
+  "data": [
+    {
+      "Task": {
+        "id": "1020355782500602947",
+        "name": "666",
+        "description": "",
+        "workspace_id": "20355782",
+        "creator": "v_tingtdong",
+        "created": "2019-10-30 16:26:45",
+        "modified": "2019-10-30 16:26:45",
+        "status": "open",
+        "owner": "",
+        "cc": "",
+        "begin": "",
+        "due": "",
+        "story_id": "1020355782500697089",
+        "iteration_id": "1020355782000390769",
+        "priority": "",
+        "progress": "0",
+        "completed": "",
+        "effort_completed": "0",
+        "exceed": "0",
+        "remain": "0",
+        "effort": "0",
+        "has_attachment": "0",
+        "release_id": "1020355782500697089"
+      }
+    }
+  ],
+  "info": "success"
+}


### PR DESCRIPTION
## Summary
Add TAPD source code commit API support for saving commit metadata, listing related Git commit data, and resolving TAPD work items associated with commits.

## Changes
- Add `SourceService` and wire it into `Client`
- Implement `AddCodeCommitInfo`, `GetCodeCommitInfos`, and `GetCommitObjects`
- Add source API fixtures and unit tests for request/response handling
- Mark the `### 源码` entries as implemented in `features.md`

## Motivation
- Complete the current source API checklist in `features.md` against the official TAPD API docs

## Testing
- `GOCACHE=/private/tmp/go-build-cache-tapd go test . -run 'TestSourceService_' -v`
- `GOCACHE=/private/tmp/go-build-cache-tapd go test ./... -race`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added source code commit management capabilities with operations to add commit information, retrieve commit records, and access commit objects

* **Tests**
  * Added comprehensive unit tests for new commit operations

* **Documentation**
  * Updated features documentation to reflect newly implemented source code API endpoints

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/go-tapd/tapd/pull/497?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->