### PR TITLE
Lower the go.mod version support from 1.25.7 to 1.25.0.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -63,9 +63,6 @@ linters:
         - '-ST1020' # https://staticcheck.dev/docs/checks#ST1020
         - '-ST1021' # https://staticcheck.dev/docs/checks#ST1021
         - '-ST1022' # https://staticcheck.dev/docs/checks#ST1022
-  exclusions:
-    paths:
-      - .gocache
 
 formatters:
   enable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,24 +5,26 @@ linters:
 
   enable:
     - bodyclose
+    - copyloopvar
     - dogsled
     - durationcheck
     - errcheck
-    - copyloopvar
-    - govet
-    - mnd
-    - misspell
-    - gocyclo
     - gocritic
+    - gocyclo
+    - gomoddirectives
+    - govet
     - ineffassign
+    - misspell
+    - modernize
+    - nolintlint
     - prealloc
     - revive
     - staticcheck
-    - unused
-    - whitespace
-    - wastedassign
     - unconvert
-    - usetesting
+    - unparam
+    - unused
+    - wastedassign
+    - whitespace
   settings:
     revive:
       # see: https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md
@@ -30,6 +32,7 @@ linters:
         - name: context-as-argument
           arguments:
             - allowTypesBefore: '*testing.T,*testing.B,*testing.F'
+        #        - name: context-keys-type
         - name: duplicated-imports
         - name: early-return
         - name: error-naming
@@ -42,12 +45,33 @@ linters:
         - name: useless-break
         - name: var-declaration
         - name: var-naming
+          arguments: [ [ ],[ ],[ skipPackageNameChecks: true ] ]
         - name: waitgroup-by-value
-    usetesting:
-      context-background: true
-      context-todo: true
+    gomoddirectives:
+      replace-local: true
+      replace-allow-list:
+        - tw8591
+      toolchain-forbidden: true
+      go-version-pattern: '^1\.26\.0$'
+    nolintlint:
+      require-specific: true
+    staticcheck:
+      checks:
+        - all
+        - '-QF1012' # https://staticcheck.dev/docs/checks#QF1012
+        - '-ST1000' # https://staticcheck.dev/docs/checks#ST1000
+        - '-ST1020' # https://staticcheck.dev/docs/checks#ST1020
+        - '-ST1021' # https://staticcheck.dev/docs/checks#ST1021
+        - '-ST1022' # https://staticcheck.dev/docs/checks#ST1022
+  exclusions:
+    paths:
+      - .gocache
 
 formatters:
   enable:
     - gofumpt
     - goimports
+  settings:
+    gofumpt:
+      extra-rules: true
+      module-path: github.com/go-tapd/tapd

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -52,7 +52,7 @@ linters:
       replace-allow-list:
         - tw8591
       toolchain-forbidden: true
-      go-version-pattern: '^1\.26\.0$'
+      go-version-pattern: '^1\.25\.0$'
     nolintlint:
       require-specific: true
     staticcheck:

--- a/api_setting.go
+++ b/api_setting.go
@@ -8,7 +8,7 @@ import (
 type (
 	GetWorkspaceSettingRequest struct {
 		WorkspaceID *int    `url:"workspace_id,omitempty"` // 项目ID
-		Type        *string `url:"type,omitempty"`         // nolint:lll // 配置名称（is_enabled_story_category 是否启用需求分类树，workspace_metrology 工时单位）
+		Type        *string `url:"type,omitempty"`         //nolint:lll // 配置名称（is_enabled_story_category 是否启用需求分类树，workspace_metrology 工时单位）
 	}
 
 	GetWorkspaceSettingResponse struct {

--- a/api_timesheet.go
+++ b/api_timesheet.go
@@ -135,13 +135,13 @@ type (
 	}
 
 	DeleteTimesheetsResponse struct {
-		Msg  string                 `json:"msg,omitempty"`  // 处理结果消息
-		Data DeleteTimesheetsResult `json:"data,omitempty"` // 删除结果明细
+		Msg  string                 `json:"msg,omitzero"`  // 处理结果消息
+		Data DeleteTimesheetsResult `json:"data,omitzero"` // 删除结果明细
 	}
 
 	DeleteTimesheetsResult struct {
-		Success DeleteTimesheetsResultItem   `json:"success,omitempty"` // 删除成功明细
-		Failed  []DeleteTimesheetsResultItem `json:"failed,omitempty"`  // 删除失败明细
+		Success DeleteTimesheetsResultItem   `json:"success,omitzero"` // 删除成功明细
+		Failed  []DeleteTimesheetsResultItem `json:"failed,omitempty"` // 删除失败明细
 	}
 
 	DeleteTimesheetsResultItem struct {

--- a/client.go
+++ b/client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"maps"
 	"net/http"
 	"net/url"
 	"strings"
@@ -214,9 +215,7 @@ func (c *Client) NewRequest(ctx context.Context, method, path string, data any, 
 	}
 
 	// Set the request specific headers.
-	for k, v := range reqHeaders {
-		req.Header[k] = v
-	}
+	maps.Copy(req.Header, reqHeaders)
 
 	// Apply request options
 	for _, opt := range opts {
@@ -235,8 +234,8 @@ func (c *Client) Do(req *http.Request, v any) (*Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()              // nolint:errcheck
-	defer io.Copy(io.Discard, resp.Body) // nolint:errcheck
+	defer resp.Body.Close()              //nolint:errcheck
+	defer io.Copy(io.Discard, resp.Body) //nolint:errcheck
 
 	// decode response body
 	var rawBody RawBody

--- a/client_test.go
+++ b/client_test.go
@@ -26,7 +26,7 @@ const (
 
 var ctx = context.Background()
 
-func createServerClient(t *testing.T, handler http.Handler) (*httptest.Server, *Client) {
+func createServerClient(t *testing.T, handler http.Handler) (*httptest.Server, *Client) { //nolint:unparam
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
 
@@ -59,7 +59,7 @@ func TestClient_BasicAuth(t *testing.T) {
 		assert.Equal(t, apiClientID, clientID)
 		assert.Equal(t, apiClientSecret, clientSecret)
 
-		// nolint:errcheck
+		//nolint:errcheck
 		fmt.Fprint(w, successResponse)
 	}))
 	assert.Equal(t, authTypeBasic, client.authType)
@@ -82,7 +82,7 @@ func TestClient_PATAuth(t *testing.T) {
 		assert.NotEmpty(t, authHeader)
 		assert.Equal(t, "Bearer "+apiAccessToken, authHeader)
 
-		// nolint:errcheck
+		//nolint:errcheck
 		fmt.Fprint(w, successResponse)
 	}))
 	t.Cleanup(srv.Close)
@@ -104,7 +104,7 @@ func TestClient_ErrorResponse(t *testing.T) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Equal(t, "/__/error-response", r.URL.Path)
 
-		// nolint:errcheck
+		//nolint:errcheck
 		fmt.Fprint(w, `{
   "status": 0,
   "data": {},
@@ -134,7 +134,7 @@ func TestClient_NormalRequest(t *testing.T) {
 		assert.Equal(t, apiClientID, clientID)
 		assert.Equal(t, apiClientSecret, clientSecret)
 
-		fmt.Fprint(w, successResponse) // nolint:errcheck
+		fmt.Fprint(w, successResponse) //nolint:errcheck
 	}))
 
 	req, err := client.NewRequest(ctx, http.MethodGet, "__/normal-request", nil, nil)
@@ -164,7 +164,7 @@ func TestClient_WithRequestOption(t *testing.T) {
 		assert.Equal(t, "test-client-id", clientID)
 		assert.Equal(t, "test-client-secret", clientSecret)
 
-		fmt.Fprint(w, successResponse) // nolint:errcheck
+		fmt.Fprint(w, successResponse) //nolint:errcheck
 	}))
 
 	req, err := client.NewRequest(ctx, http.MethodGet, "__/request-option", nil, []RequestOption{
@@ -265,7 +265,7 @@ func TestClient_WithRequestOption_WithAuth(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				tt.wantFunc(t, r)
-				fmt.Fprint(w, successResponse) // nolint:errcheck
+				fmt.Fprint(w, successResponse) //nolint:errcheck
 			}))
 
 			client, err := tt.createClientFunc(srv)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-tapd/tapd
 
-go 1.25.7
+go 1.25.0
 
 tool github.com/golangci/golangci-lint/v2/cmd/golangci-lint
 

--- a/webhook/dispatcher_test.go
+++ b/webhook/dispatcher_test.go
@@ -84,7 +84,7 @@ func TestDispatcher_Dispatch(t *testing.T) {
 			handler(w, req)
 
 			resp := w.Result()
-			defer resp.Body.Close() // nolint:errcheck
+			defer resp.Body.Close() //nolint:errcheck
 
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
 			buf, err := io.ReadAll(resp.Body)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Go linter configuration to improve code quality checks.
  * Updated Go toolchain requirement to version 1.25.0.
  * Adjusted JSON response serialization behavior for consistency in API responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/go-tapd/tapd/pull/500?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->