### PR TITLE
docs(readme): promote cli sibling project

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,12 @@ If you encounter any issues, you are welcome to [submit an issue](https://github
 ## 🧰 Command Line Tool
 
 > [!NOTE]
-> Prefer terminal or CI usage? Try the sibling project
+> 🧰 Prefer terminal or CI usage? Try the sibling project
 > [`go-tapd/cli`](https://github.com/go-tapd/cli), a command line tool built on
-> this SDK. See the repository for installation and usage examples.
+> this SDK.
+>
+> ⚙️ Use the CLI for quick local operations, shell scripts, and automation. See
+> the repository for installation and usage examples.
 
 ## 📥 Installation
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ The Go-Tapd-SDK is a Go client library for accessing the [Tapd API](https://www.
 
 If you encounter any issues, you are welcome to [submit an issue](https://github.com/go-tapd/tapd/issues/new).
 
+## 🧰 Command Line Tool
+
+> [!NOTE]
+> Prefer terminal or CI usage? Try the sibling project
+> [`go-tapd/cli`](https://github.com/go-tapd/cli), a command line tool built on
+> this SDK. See the repository for installation and usage examples.
+
 ## 📥 Installation
 
 ```bash


### PR DESCRIPTION
## Summary
Add a short README note that points terminal and CI users to the sibling go-tapd/cli project.

## Changes
- Add a GitHub NOTE block before SDK installation
- Link to the go-tapd/cli repository and clarify its relationship to this SDK

## Motivation
- Help users discover the CLI when they need command line access instead of a Go library

## Testing
- Ran git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with guidance recommending the Command Line Tool for local development and automation workflows, including references to installation and usage examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/go-tapd/tapd/pull/501?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->