### PR TITLE
feat(attachment): add attachment upload APIs

### DIFF
--- a/api_attachment.go
+++ b/api_attachment.go
@@ -44,13 +44,15 @@ type (
 	}
 
 	GetAttachmentsRequest struct {
-		WorkspaceID *int    `url:"workspace_id,omitempty"`  // [必须]项目ID
-		ID          *int    `url:"id,omitempty"`            // [可选]ID
-		Type        *string `url:"type,omitempty"`          // [可选]类型
-		EntryID     *int    `url:"entry_id,omitempty"`      // [可选]依赖对象ID
-		Filename    *string `url:"filename,omitempty"`      // [可选]附件名称
-		Owner       *string `url:"owner,omitempty"`         // [可选]上传人
-		DownloadURL string  `json:"download_url,omitempty"` // 下载链接(仅在获取单个附件时返回)
+		WorkspaceID *int    `url:"workspace_id,omitempty"` // [必须]项目ID
+		ID          *int    `url:"id,omitempty"`           // [可选]ID
+		Type        *string `url:"type,omitempty"`         // [可选]类型
+		EntryID     *int    `url:"entry_id,omitempty"`     // [可选]依赖对象ID
+		Filename    *string `url:"filename,omitempty"`     // [可选]附件名称
+		Owner       *string `url:"owner,omitempty"`        // [可选]上传人
+		Limit       *int    `url:"limit,omitempty"`        // [可选]每页数量，最大 200
+		Page        *int    `url:"page,omitempty"`         // [可选]页码
+		DownloadURL string  `url:"-" json:"download_url,omitempty"`
 	}
 
 	GetAttachmentDownloadURLRequest struct {
@@ -108,6 +110,7 @@ type AttachmentService interface {
 	// GetAttachments 获取附件
 	//
 	// https://open.tapd.cn/document/api-doc/API%E6%96%87%E6%A1%A3/api_reference/attachment/get_attachments.html
+	// https://open.tapd.cn/document/api-doc/API%E6%96%87%E6%A1%A3/mini_api_reference/attachment/get_attachments.html
 	GetAttachments(ctx context.Context, request *GetAttachmentsRequest, opts ...RequestOption) ([]*Attachment, *Response, error)
 
 	// GetAttachmentDownloadURL 获取单个附件下载链接

--- a/api_attachment.go
+++ b/api_attachment.go
@@ -34,6 +34,15 @@ type (
 		File        io.Reader `url:"-"`                      // [必须]文件内容
 	}
 
+	UploadImageBase64Request struct {
+		WorkspaceID *int    `url:"workspace_id,omitempty"` // [必须]空间ID
+		Base64Data  *string `url:"base64_data,omitempty"`  // [必须]图片 base64 格式数据
+		Type        *string `url:"type,omitempty"`         // [必须]类型，固定为 story_custom_field
+		CustomField *string `url:"custom_field,omitempty"` // [必须]字段英文名
+		EntryID     *int64  `url:"entry_id,omitempty"`     // [必须]工作项ID
+		Owner       *string `url:"owner,omitempty"`        // [可选]附件创建人
+	}
+
 	GetAttachmentsRequest struct {
 		WorkspaceID *int    `url:"workspace_id,omitempty"`  // [必须]项目ID
 		ID          *int    `url:"id,omitempty"`            // [可选]ID
@@ -90,6 +99,11 @@ type AttachmentService interface {
 	//
 	// https://open.tapd.cn/document/api-doc/API%E6%96%87%E6%A1%A3/mini_api_reference/attachment/upload_attachment.html
 	UploadAttachment(ctx context.Context, request *UploadAttachmentRequest, opts ...RequestOption) (*Attachment, *Response, error)
+
+	// UploadImageBase64 上传base64图片
+	//
+	// https://open.tapd.cn/document/api-doc/API%E6%96%87%E6%A1%A3/mini_api_reference/attachment/upload_image_base64.html
+	UploadImageBase64(ctx context.Context, request *UploadImageBase64Request, opts ...RequestOption) (*Attachment, *Response, error)
 
 	// GetAttachments 获取附件
 	//
@@ -181,10 +195,63 @@ func (s *attachmentService) UploadAttachment(
 	return response.Attachment, resp, nil
 }
 
+func (s *attachmentService) UploadImageBase64(
+	ctx context.Context, request *UploadImageBase64Request, opts ...RequestOption,
+) (*Attachment, *Response, error) {
+	if request == nil {
+		return nil, nil, errors.New("tapd: upload image base64 request is nil")
+	}
+
+	req, err := s.client.newMultipartRequest(
+		ctx,
+		"files/upload_image_base64",
+		uploadImageBase64Fields(request),
+		nil,
+		opts,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var response struct {
+		Attachment *Attachment `json:"Attachment,omitempty"`
+	}
+	resp, err := s.client.Do(req, &response)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return response.Attachment, resp, nil
+}
+
 func uploadAttachmentFields(request *UploadAttachmentRequest) map[string]string {
 	fields := make(map[string]string)
 	if request.WorkspaceID != nil {
 		fields["workspace_id"] = strconv.Itoa(*request.WorkspaceID)
+	}
+	if request.Type != nil {
+		fields["type"] = *request.Type
+	}
+	if request.CustomField != nil {
+		fields["custom_field"] = *request.CustomField
+	}
+	if request.EntryID != nil {
+		fields["entry_id"] = strconv.FormatInt(*request.EntryID, 10)
+	}
+	if request.Owner != nil {
+		fields["owner"] = *request.Owner
+	}
+
+	return fields
+}
+
+func uploadImageBase64Fields(request *UploadImageBase64Request) map[string]string {
+	fields := make(map[string]string)
+	if request.WorkspaceID != nil {
+		fields["workspace_id"] = strconv.Itoa(*request.WorkspaceID)
+	}
+	if request.Base64Data != nil {
+		fields["base64_data"] = *request.Base64Data
 	}
 	if request.Type != nil {
 		fields["type"] = *request.Type

--- a/api_attachment.go
+++ b/api_attachment.go
@@ -113,6 +113,7 @@ type AttachmentService interface {
 	// GetAttachmentDownloadURL 获取单个附件下载链接
 	//
 	// https://open.tapd.cn/document/api-doc/API%E6%96%87%E6%A1%A3/api_reference/attachment/get_one_attachment.html
+	// https://open.tapd.cn/document/api-doc/API%E6%96%87%E6%A1%A3/mini_api_reference/attachment/get_one_attachment.html
 	GetAttachmentDownloadURL(ctx context.Context, request *GetAttachmentDownloadURLRequest, opts ...RequestOption) (*Attachment, *Response, error)
 
 	// GetImageDownloadURL 获取单个图片下载链接

--- a/api_attachment.go
+++ b/api_attachment.go
@@ -2,7 +2,11 @@ package tapd
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
+	"strconv"
 )
 
 type (
@@ -18,6 +22,16 @@ type (
 		WorkspaceID string `json:"workspace_id,omitempty"` // 项目ID
 		Owner       string `json:"owner,omitempty"`        // 上传人
 		DownloadURL string `json:"download_url,omitempty"` // 下载链接(仅在获取单个附件时返回)
+	}
+
+	UploadAttachmentRequest struct {
+		WorkspaceID *int      `url:"workspace_id,omitempty"` // [必须]空间ID
+		Type        *string   `url:"type,omitempty"`         // [必须]类型，固定为 story_custom_field
+		CustomField *string   `url:"custom_field,omitempty"` // [必须]字段英文名
+		EntryID     *int64    `url:"entry_id,omitempty"`     // [必须]工作项ID
+		Owner       *string   `url:"owner,omitempty"`        // [可选]附件创建人
+		Filename    *string   `url:"-"`                      // [必须]上传文件名
+		File        io.Reader `url:"-"`                      // [必须]文件内容
 	}
 
 	GetAttachmentsRequest struct {
@@ -72,6 +86,11 @@ type (
 //
 // https://open.tapd.cn/document/api-doc/API%E6%96%87%E6%A1%A3/api_reference/attachment/
 type AttachmentService interface {
+	// UploadAttachment 附件上传
+	//
+	// https://open.tapd.cn/document/api-doc/API%E6%96%87%E6%A1%A3/mini_api_reference/attachment/upload_attachment.html
+	UploadAttachment(ctx context.Context, request *UploadAttachmentRequest, opts ...RequestOption) (*Attachment, *Response, error)
+
 	// GetAttachments 获取附件
 	//
 	// https://open.tapd.cn/document/api-doc/API%E6%96%87%E6%A1%A3/api_reference/attachment/get_attachments.html
@@ -103,6 +122,84 @@ func NewAttachmentService(client *Client) AttachmentService {
 	return &attachmentService{
 		client: client,
 	}
+}
+
+func (a *Attachment) UnmarshalJSON(data []byte) error {
+	type attachment Attachment
+	var raw struct {
+		*attachment
+		ID          json.RawMessage `json:"id,omitempty"`
+		EntryID     json.RawMessage `json:"entry_id,omitempty"`
+		WorkspaceID json.RawMessage `json:"workspace_id,omitempty"`
+	}
+	raw.attachment = (*attachment)(a)
+
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	a.ID = stringifyJSONRaw(raw.ID)
+	a.EntryID = stringifyJSONRaw(raw.EntryID)
+	a.WorkspaceID = stringifyJSONRaw(raw.WorkspaceID)
+
+	return nil
+}
+
+func (s *attachmentService) UploadAttachment(
+	ctx context.Context, request *UploadAttachmentRequest, opts ...RequestOption,
+) (*Attachment, *Response, error) {
+	if request == nil {
+		return nil, nil, errors.New("tapd: upload attachment request is nil")
+	}
+	if request.Filename == nil || *request.Filename == "" {
+		return nil, nil, errors.New("tapd: upload attachment filename is empty")
+	}
+
+	req, err := s.client.newMultipartRequest(
+		ctx,
+		"files/upload_attachment",
+		uploadAttachmentFields(request),
+		&multipartFile{
+			fieldName: "file",
+			fileName:  *request.Filename,
+			body:      request.File,
+		},
+		opts,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var response struct {
+		Attachment *Attachment `json:"Attachment,omitempty"`
+	}
+	resp, err := s.client.Do(req, &response)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return response.Attachment, resp, nil
+}
+
+func uploadAttachmentFields(request *UploadAttachmentRequest) map[string]string {
+	fields := make(map[string]string)
+	if request.WorkspaceID != nil {
+		fields["workspace_id"] = strconv.Itoa(*request.WorkspaceID)
+	}
+	if request.Type != nil {
+		fields["type"] = *request.Type
+	}
+	if request.CustomField != nil {
+		fields["custom_field"] = *request.CustomField
+	}
+	if request.EntryID != nil {
+		fields["entry_id"] = strconv.FormatInt(*request.EntryID, 10)
+	}
+	if request.Owner != nil {
+		fields["owner"] = *request.Owner
+	}
+
+	return fields
 }
 
 func (s *attachmentService) GetAttachments(

--- a/api_attachment_test.go
+++ b/api_attachment_test.go
@@ -55,6 +55,44 @@ func TestAttachmentService_UploadAttachment(t *testing.T) {
 	assert.Equal(t, "go-tapd", attachment.Owner)
 }
 
+func TestAttachmentService_UploadImageBase64(t *testing.T) {
+	_, client := createServerClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/files/upload_image_base64", r.URL.Path)
+		assert.Contains(t, r.Header.Get("Content-Type"), "multipart/form-data; boundary=")
+
+		err := r.ParseMultipartForm(1024)
+		assert.NoError(t, err)
+		assert.Equal(t, "69995768", r.FormValue("workspace_id"))
+		assert.Equal(t, "story_custom_field", r.FormValue("type"))
+		assert.Equal(t, "custom_field_one", r.FormValue("custom_field"))
+		assert.Equal(t, "1069995768115415038", r.FormValue("entry_id"))
+		assert.Equal(t, "go-tapd", r.FormValue("owner"))
+		assert.Equal(t, "base64-image-data", r.FormValue("base64_data"))
+
+		_, _, err = r.FormFile("file")
+		assert.Error(t, err)
+
+		_, _ = w.Write(loadData(t, "internal/testdata/api/attachment/upload_image_base64.json"))
+	}))
+
+	attachment, _, err := client.AttachmentService.UploadImageBase64(ctx, &UploadImageBase64Request{
+		WorkspaceID: Ptr(69995768),
+		Type:        Ptr("story_custom_field"),
+		CustomField: Ptr("custom_field_one"),
+		EntryID:     Ptr[int64](1069995768115415038),
+		Owner:       Ptr("go-tapd"),
+		Base64Data:  Ptr("base64-image-data"),
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "1069995768523406033", attachment.ID)
+	assert.Equal(t, "story_custom_field", attachment.Type)
+	assert.Equal(t, "1069995768115415038", attachment.EntryID)
+	assert.Equal(t, "tapd_base64_3031935_1701845640.jpg", attachment.Filename)
+	assert.Equal(t, "image/png", attachment.ContentType)
+	assert.Equal(t, "2023-12-05 14:54:01", attachment.Created)
+}
+
 func TestAttachmentService_GetAttachments(t *testing.T) {
 	_, client := createServerClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)

--- a/api_attachment_test.go
+++ b/api_attachment_test.go
@@ -1,11 +1,59 @@
 package tapd
 
 import (
+	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestAttachmentService_UploadAttachment(t *testing.T) {
+	_, client := createServerClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/files/upload_attachment", r.URL.Path)
+		assert.Contains(t, r.Header.Get("Content-Type"), "multipart/form-data; boundary=")
+
+		err := r.ParseMultipartForm(1024)
+		assert.NoError(t, err)
+		assert.Equal(t, "11112222", r.FormValue("workspace_id"))
+		assert.Equal(t, "story_custom_field", r.FormValue("type"))
+		assert.Equal(t, "custom_field_one", r.FormValue("custom_field"))
+		assert.Equal(t, "1069993260856110917", r.FormValue("entry_id"))
+		assert.Equal(t, "go-tapd", r.FormValue("owner"))
+
+		file, header, err := r.FormFile("file")
+		assert.NoError(t, err)
+		defer file.Close() //nolint:errcheck
+		assert.Equal(t, "orangetest.jpg", header.Filename)
+
+		content, err := io.ReadAll(file)
+		assert.NoError(t, err)
+		assert.Equal(t, "demo image content", string(content))
+
+		_, _ = w.Write(loadData(t, "internal/testdata/api/attachment/upload_attachment.json"))
+	}))
+
+	attachment, _, err := client.AttachmentService.UploadAttachment(ctx, &UploadAttachmentRequest{
+		WorkspaceID: Ptr(11112222),
+		Type:        Ptr("story_custom_field"),
+		CustomField: Ptr("custom_field_one"),
+		EntryID:     Ptr[int64](1069993260856110917),
+		Owner:       Ptr("go-tapd"),
+		Filename:    Ptr("orangetest.jpg"),
+		File:        strings.NewReader("demo image content"),
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "1069993260503455439", attachment.ID)
+	assert.Equal(t, "story_custom_field", attachment.Type)
+	assert.Equal(t, "1069993260856110917", attachment.EntryID)
+	assert.Equal(t, "orangetest.jpg", attachment.Filename)
+	assert.Equal(t, "image/jpeg", attachment.ContentType)
+	assert.Equal(t, "2023-07-07 21:36:08", attachment.Created)
+	assert.Equal(t, "69993260", attachment.WorkspaceID)
+	assert.Equal(t, "go-tapd", attachment.Owner)
+}
 
 func TestAttachmentService_GetAttachments(t *testing.T) {
 	_, client := createServerClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/api_attachment_test.go
+++ b/api_attachment_test.go
@@ -104,6 +104,9 @@ func TestAttachmentService_GetAttachments(t *testing.T) {
 		assert.Equal(t, "55556666", r.URL.Query().Get("entry_id"))
 		assert.Equal(t, "demo.jpg", r.URL.Query().Get("filename"))
 		assert.Equal(t, "go-tapd", r.URL.Query().Get("owner"))
+		assert.Equal(t, "200", r.URL.Query().Get("limit"))
+		assert.Equal(t, "2", r.URL.Query().Get("page"))
+		assert.Empty(t, r.URL.Query().Get("DownloadURL"))
 
 		_, _ = w.Write(loadData(t, "internal/testdata/api/attachment/get_attachments.json"))
 	}))
@@ -115,6 +118,8 @@ func TestAttachmentService_GetAttachments(t *testing.T) {
 		EntryID:     Ptr(55556666),
 		Filename:    Ptr("demo.jpg"),
 		Owner:       Ptr("go-tapd"),
+		Limit:       Ptr(200),
+		Page:        Ptr(2),
 	})
 	assert.NoError(t, err)
 	assert.True(t, len(attachments) > 0)

--- a/api_tcase.go
+++ b/api_tcase.go
@@ -1573,16 +1573,3 @@ func parseJSONInt(raw json.RawMessage) (int, error) {
 
 	return value, nil
 }
-
-func stringifyJSONRaw(raw json.RawMessage) string {
-	if len(raw) == 0 || string(raw) == "null" {
-		return ""
-	}
-	if raw[0] != '"' {
-		return string(raw)
-	}
-
-	var value string
-	_ = json.Unmarshal(raw, &value)
-	return value
-}

--- a/client.go
+++ b/client.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"io"
 	"maps"
+	"mime/multipart"
 	"net/http"
 	"net/url"
 	"strings"
@@ -157,23 +158,14 @@ func (c *Client) setBaseURL(urlStr string) error {
 }
 
 func (c *Client) NewRequest(ctx context.Context, method, path string, data any, opts []RequestOption) (*http.Request, error) { //nolint:lll
-	u := *c.baseURL
-	unescaped, err := url.PathUnescape(path)
+	u, err := c.newRequestURL(path)
 	if err != nil {
 		return nil, err
 	}
 
-	// Set the encoded path data
-	u.RawPath = c.baseURL.Path + path
-	u.Path = c.baseURL.Path + unescaped
-
 	// Create a request specific headers map.
 	reqHeaders := make(http.Header)
 	reqHeaders.Set("Accept", "application/json")
-
-	if c.userAgent != "" {
-		reqHeaders.Set("User-Agent", c.userAgent)
-	}
 
 	var body io.Reader
 	switch {
@@ -194,6 +186,87 @@ func (c *Client) NewRequest(ctx context.Context, method, path string, data any, 
 		}
 		u.RawQuery = q.Encode()
 	}
+
+	return c.newRequest(ctx, method, u, body, reqHeaders, opts)
+}
+
+type multipartFile struct {
+	fieldName string
+	fileName  string
+	body      io.Reader
+}
+
+func (c *Client) newMultipartRequest(
+	ctx context.Context,
+	path string,
+	fields map[string]string,
+	file *multipartFile,
+	opts []RequestOption,
+) (*http.Request, error) {
+	if file == nil || file.body == nil {
+		return nil, errors.New("tapd: multipart file body is nil")
+	}
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+
+	for name, value := range fields {
+		if err := writer.WriteField(name, value); err != nil {
+			return nil, err
+		}
+	}
+
+	part, err := writer.CreateFormFile(file.fieldName, file.fileName)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := io.Copy(part, file.body); err != nil {
+		return nil, err
+	}
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+
+	u, err := c.newRequestURL(path)
+	if err != nil {
+		return nil, err
+	}
+
+	reqHeaders := make(http.Header)
+	reqHeaders.Set("Accept", "application/json")
+	reqHeaders.Set("Content-Type", writer.FormDataContentType())
+
+	return c.newRequest(ctx, http.MethodPost, u, &body, reqHeaders, opts)
+}
+
+func (c *Client) newRequestURL(path string) (*url.URL, error) {
+	u := *c.baseURL
+	unescaped, err := url.PathUnescape(path)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set the encoded path data
+	u.RawPath = c.baseURL.Path + path
+	u.Path = c.baseURL.Path + unescaped
+
+	return &u, nil
+}
+
+func (c *Client) newRequest(
+	ctx context.Context,
+	method string,
+	u *url.URL,
+	body io.Reader,
+	headers http.Header,
+	opts []RequestOption,
+) (*http.Request, error) {
+	reqHeaders := make(http.Header)
+
+	if c.userAgent != "" {
+		reqHeaders.Set("User-Agent", c.userAgent)
+	}
+	maps.Copy(reqHeaders, headers)
 
 	req, err := http.NewRequestWithContext(ctx, method, u.String(), body)
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -203,10 +203,6 @@ func (c *Client) newMultipartRequest(
 	file *multipartFile,
 	opts []RequestOption,
 ) (*http.Request, error) {
-	if file == nil || file.body == nil {
-		return nil, errors.New("tapd: multipart file body is nil")
-	}
-
 	var body bytes.Buffer
 	writer := multipart.NewWriter(&body)
 
@@ -216,12 +212,18 @@ func (c *Client) newMultipartRequest(
 		}
 	}
 
-	part, err := writer.CreateFormFile(file.fieldName, file.fileName)
-	if err != nil {
-		return nil, err
-	}
-	if _, err := io.Copy(part, file.body); err != nil {
-		return nil, err
+	if file != nil {
+		if file.body == nil {
+			return nil, errors.New("tapd: multipart file body is nil")
+		}
+
+		part, err := writer.CreateFormFile(file.fieldName, file.fileName)
+		if err != nil {
+			return nil, err
+		}
+		if _, err := io.Copy(part, file.body); err != nil {
+			return nil, err
+		}
 	}
 	if err := writer.Close(); err != nil {
 		return nil, err

--- a/features.md
+++ b/features.md
@@ -379,7 +379,7 @@ API 文档：https://open.tapd.cn/document/api-doc/API%E6%96%87%E6%A1%A3/
 - [x] 附件上传
 - [x] 上传base64图片
 - [x] 获取单个附件下载链接
-- [ ] 获取附件
+- [x] 获取附件
 
 ### 应用集成-工蜂 
 

--- a/features.md
+++ b/features.md
@@ -376,7 +376,7 @@ API 文档：https://open.tapd.cn/document/api-doc/API%E6%96%87%E6%A1%A3/
 
 ### 附件
 
-- [ ] 附件上传
+- [x] 附件上传
 - [ ] 上传base64图片
 - [ ] 获取单个附件下载链接
 - [ ] 获取附件

--- a/features.md
+++ b/features.md
@@ -377,7 +377,7 @@ API 文档：https://open.tapd.cn/document/api-doc/API%E6%96%87%E6%A1%A3/
 ### 附件
 
 - [x] 附件上传
-- [ ] 上传base64图片
+- [x] 上传base64图片
 - [ ] 获取单个附件下载链接
 - [ ] 获取附件
 

--- a/features.md
+++ b/features.md
@@ -378,7 +378,7 @@ API 文档：https://open.tapd.cn/document/api-doc/API%E6%96%87%E6%A1%A3/
 
 - [x] 附件上传
 - [x] 上传base64图片
-- [ ] 获取单个附件下载链接
+- [x] 获取单个附件下载链接
 - [ ] 获取附件
 
 ### 应用集成-工蜂 

--- a/helpers.go
+++ b/helpers.go
@@ -1,6 +1,21 @@
 package tapd
 
+import "encoding/json"
+
 // Ptr returns a pointer to the value.
 func Ptr[T any](v T) *T {
 	return &v
+}
+
+func stringifyJSONRaw(raw json.RawMessage) string {
+	if len(raw) == 0 || string(raw) == "null" {
+		return ""
+	}
+	if raw[0] != '"' {
+		return string(raw)
+	}
+
+	var value string
+	_ = json.Unmarshal(raw, &value)
+	return value
 }

--- a/internal/testdata/api/attachment/upload_attachment.json
+++ b/internal/testdata/api/attachment/upload_attachment.json
@@ -1,0 +1,17 @@
+{
+  "status": 1,
+  "data": {
+    "Attachment": {
+      "id": "1069993260503455439",
+      "type": "story_custom_field",
+      "entry_id": 1069993260856110917,
+      "filename": "orangetest.jpg",
+      "description": "",
+      "content_type": "image/jpeg",
+      "created": "2023-07-07 21:36:08",
+      "workspace_id": 69993260,
+      "owner": "go-tapd"
+    }
+  },
+  "info": "success"
+}

--- a/internal/testdata/api/attachment/upload_image_base64.json
+++ b/internal/testdata/api/attachment/upload_image_base64.json
@@ -1,0 +1,15 @@
+{
+  "status": 1,
+  "data": {
+    "Attachment": {
+      "id": "1069995768523406033",
+      "type": "story_custom_field",
+      "entry_id": 1069995768115415038,
+      "filename": "tapd_base64_3031935_1701845640.jpg",
+      "description": "",
+      "content_type": "image/png",
+      "created": "2023-12-05 14:54:01"
+    }
+  },
+  "info": "success"
+}


### PR DESCRIPTION
## Summary
Add TAPD attachment upload support, including multipart file uploads and base64 image uploads, and align the light-collaboration attachment checklist with the SDK coverage.

## Changes
- Add UploadAttachment and UploadImageBase64 APIs to AttachmentService
- Add multipart/form-data request construction shared by file and form-only uploads
- Make Attachment ID fields tolerate string or numeric JSON values
- Add pagination fields to GetAttachments and stop encoding DownloadURL as a query parameter
- Mark the light-collaboration attachment APIs covered in features.md

## Motivation
- Closes #509
- TAPD officially documents attachment upload endpoints that were not exposed by the SDK

## Testing
- go test . -run TestAttachmentService -v
- go test . -run TestAttachmentService_GetAttachments -v
- make test
- make lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added attachment upload functionality to the API
  * Added support for uploading images as base64-encoded data
  * Added pagination parameters for retrieving attachments

* **Documentation**
  * Updated feature list to mark attachment-related APIs as implemented

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/go-tapd/tapd/pull/510?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->